### PR TITLE
fix: assert not USING_SLIDING_WINDOW

### DIFF
--- a/timber/models/timber_attention/attention1_block_gpu.py
+++ b/timber/models/timber_attention/attention1_block_gpu.py
@@ -805,7 +805,7 @@ def hip_attention_mask(
     SPARQ_HID: int = 32,
     SPARQ_REDUCE_METHOD: Literal['sum', 'max'] = 'sum',
     
-    IS_FLASH: bool = False,
+    IS_FLASH: bool = True,
     
     # NOTE: this improve latency quite well, but hurt accuracy
     ESTIMATOR_LOWER_RESOLUTION: int = 2,
@@ -1814,7 +1814,7 @@ def timber_attention(
     chunking: bool = False,
     chunk_size: int = 2048,
 
-    is_flash: bool = False,
+    is_flash: bool = True,
     enable_sparq: bool = False,
     
     sampling_method: str = 'random',


### PR DESCRIPTION
This is a fix for an error I got:

  File "/home/liam/miniconda3/envs/vllm-hip/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1520, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/liam/Projects/vllm/vllm/model_executor/layers/attention/attention.py", line 79, in forward
    return self.backend.forward(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/liam/Projects/vllm/vllm/model_executor/layers/attention/backends/hip.py", line 211, in forward
    output, _ = timber_attention(
                ^^^^^^^^^^^^^^^^^
  File "/home/liam/Projects/hip-attention/timber/models/timber_attention/attention1_block_gpu.py", line 2047, in timber_attention
    indices, ks = hip_attention_mask(
                  ^^^^^^^^^^^^^^^^^^^
  File "/home/liam/Projects/hip-attention/timber/models/timber_attention/attention1_block_gpu.py", line 1050, in hip_attention_mask
    assert not USING_SLIDING_WINDOW
           ^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError