### PR TITLE
Feat: Support dynamic k for each query and head

### DIFF
--- a/hip/models/hip_attention/tests/test_attention1_block_gpu_bwd.py
+++ b/hip/models/hip_attention/tests/test_attention1_block_gpu_bwd.py
@@ -38,11 +38,11 @@ def test_sparse_attention():
             n_patches=n_patches,
             mask_k=mask_k,
             scale_up=scale_up,
-            BLOCK_SIZE_Q=block_size_q,
-            BLOCK_SIZE_K=block_size_k,
+            block_size_q=block_size_q,
+            block_size_k=block_size_k,
             
             is_causal=False,
-            IS_FLASH=False,
+            is_flash=False,
         )
         
     v = nn.Parameter(v)
@@ -108,11 +108,11 @@ def test_attention_mask():
             n_patches=n_patches,
             mask_k=mask_k,
             scale_up=scale_up,
-            BLOCK_SIZE_Q=block_size_q,
-            BLOCK_SIZE_K=block_size_k,
+            block_size_q=block_size_q,
+            block_size_k=block_size_k,
             
             is_causal=False,
-            IS_FLASH=False,
+            is_flash=False,
         )
         
         loss = probs.std() * 1000

--- a/hip/models/hip_attention/tests/test_attention1_block_gpu_fwd.py
+++ b/hip/models/hip_attention/tests/test_attention1_block_gpu_fwd.py
@@ -65,8 +65,8 @@ def main():
         n_patches,
         mask_k,
         scale_up,
-        BLOCK_SIZE_Q=BLOCKSIZE_Q,
-        BLOCK_SIZE_K=BLOCKSIZE_K,
+        block_size_q=BLOCKSIZE_Q,
+        block_size_k=BLOCKSIZE_K,
     )
     
     print(q.shape, indices.shape, ks.shape, probs.shape, scores.shape)


### PR DESCRIPTION
# Description

For research purposes, I introduce `k` controllability for each `batch` x `head` x `query block.`

This could be a useful feature for fine-grained control of sparsity, rather than uniform definition of `k`.

# Example

The `maximum_ks` should be shaped as `[N, BDST]` where `N` is `number of batch size x number of head size`, and `BDST` is `cdiv(number of query, block size q)`.

```py
# caller can pass predefined maximum ks for each query and heads in the shape of int[N, BDST]
maximum_ks = ((torch.arange(
    0, q.shape[1] // block_size_q, device=q.device
) % 2) * (mask_k // 2) + mask_k // 2)[None, :].repeat(q.shape[0], 1)

# or maximum_ks could be just None
maximum_ks = None

context, (
    atten_indices, 
    atten_ks, 
    atten_probs
) = hip_attention(
    q, k, v,
    mask_k=mask_k,
    block_size_q=block_size_q,
    block_size_k=block_size_k,
    maximum_ks=maximum_ks,
)
```

# Breaking changes

The function arguments are changed to snake cases.