### PR TITLE
Handling ROCm

### DIFF
--- a/src/hip_attn/v1_1/attention2_draft_prefetch.py
+++ b/src/hip_attn/v1_1/attention2_draft_prefetch.py
@@ -43,7 +43,10 @@ from hip_attn.v1_0.attention1_block_gpu import to_dense
 try:
     from vllm_flash_attn import flash_attn_func, flash_attn_with_kvcache
 except ImportError:
-    from flash_attn import flash_attn_func, flash_attn_with_kvcache
+    try:
+        from flash_attn import flash_attn_func, flash_attn_with_kvcache
+    except ImportError:
+        flash_attn_func = flash_attn_with_kvcache = None
 
 
 def cdiv_python(a, b):

--- a/src/hip_attn/v1_2/attention_extend_bsa.py
+++ b/src/hip_attn/v1_2/attention_extend_bsa.py
@@ -575,7 +575,7 @@ def get_block_sparse_attention_configs():
                 num_stages=2,
                 maxnreg=256,
             ),
-        }.get(device_name, dict(num_warps=4, num_stages=2, maxnreg=256))
+        }.get(device_name, dict(num_warps=4, num_stages=2))
         return [triton.Config({}, **defaults)]
     if os.getenv("HIP_DISABLE_AUTOTUNE_WARNINGS", "0") == "0":
         warnings.warn(


### PR DESCRIPTION
Migration to ROCm from the CUDA platform does not seem to require lots of work, but it needs some environment setup.

Related SGL PR: https://github.com/DeepAuto-AI/sglang/pull/16

# Environment

Tested environment: RunPod MI300X pytorch:2.4.0-py3.10-rocm6.1.0-ubuntu22.04
Tested ROCm version: **rocm-6.3.0, I reinstalled ROCm by overriding 6.1 that provided by RunPod** 
`(rocm-installer_1.0.0.60301-1~22.04.run)`

<details>
<summary> pip freeze result </summary>

```
accelerate==1.5.2
aiohappyeyeballs==2.6.1
aiohttp==3.11.14
aiohttp-cors==0.8.0
aiosignal==1.3.2
airportsdata==20250224
amdsmi @ file:///opt/rocm/share/amd_smi
annotated-types==0.7.0
anthropic==0.49.0
anyio==4.9.0
astor==0.8.1
asttokens==3.0.0
async-timeout==5.0.1
attrs==25.3.0
awscli==1.38.16
axial_positional_embedding==0.3.12
bitsandbytes==0.45.3
blake3==1.0.4
boto3==1.37.16
botocore==1.37.16
cachetools==5.5.2
certifi==2025.1.31
cfgv==3.4.0
charset-normalizer==3.4.1
clang==20.1.0
click==8.1.8
cloudpickle==3.1.1
cmake==3.31.6
colorama==0.4.6
colorful==0.5.6
compressed-tensors==0.9.2
contourpy==1.3.1
cuda-bindings==12.8.0
cupy-cuda12x==13.4.0
cycler==0.12.1
datasets==3.4.1
decorator==5.2.1
decord==0.6.0
depyf==0.18.0
dill==0.3.8
diskcache==5.6.3
distlib==0.3.9
distro==1.9.0
dnspython==2.7.0
docutils==0.16
einops==0.8.1
email_validator==2.2.0
exceptiongroup==1.2.2
executing==2.2.0
fastapi==0.115.11
fastapi-cli==0.0.7
fastrlock==0.8.3
filelock==3.18.0
flashinfer-python==0.2.3
fonttools==4.56.0
frozenlist==1.5.0
fsspec==2024.6.1
gguf==0.10.0
google-api-core==2.24.2
google-auth==2.38.0
googleapis-common-protos==1.69.2
grpcio==1.71.0
h11==0.14.0
hf_transfer==0.1.9
-e git+ssh://git@github.com/DeepAuto-AI/hip-attention.git@6c9133219793dfebc714160db96977f76d656939#egg=hip_attn
hip-python @ file:///root/library/hip-python/hip-python/dist/hip_python-6.3.3.541.31-cp310-cp310-linux_x86_64.whl#sha256=b735e6685fe5e14c13332ce197d42d8906490f5f18570b17850c487724fc37dc
hip-python-as-cuda @ file:///root/library/hip-python/hip-python-as-cuda/dist/hip_python_as_cuda-6.3.3.541.31-cp310-cp310-linux_x86_64.whl#sha256=400ddec979e44ed070024d69c8ee1eb55c263283ae5a8fe82ef3f6fc790e7807
hiredis==3.1.0
httpcore==1.0.7
httptools==0.6.4
httpx==0.28.1
huggingface-hub==0.29.3
humanize==4.12.1
hyper-connections==0.1.15
identify==2.6.9
idna==3.10
importlib_metadata==8.6.1
iniconfig==2.1.0
interegular==0.3.3
ipython==8.34.0
jedi==0.19.2
Jinja2==3.1.6
jiter==0.9.0
jmespath==1.0.1
jsonschema==4.23.0
jsonschema-specifications==2024.10.1
kiwisolver==1.4.8
lark==1.2.2
libnacl==2.1.0
litellm==1.63.12
llguidance==0.7.4
llvmlite==0.43.0
lm-format-enforcer==0.10.11
local-attention==1.11.1
markdown-it-py==3.0.0
MarkupSafe==2.1.5
matplotlib==3.10.1
matplotlib-inline==0.1.7
mdurl==0.1.2
mistral_common==1.5.4
modelscope==1.24.0
mpmath==1.3.0
msgpack==1.1.0
msgspec==0.19.0
multidict==6.2.0
multiprocess==0.70.16
nest-asyncio==1.6.0
networkx==3.3
ninja==1.11.1.3
nodeenv==1.9.1
numba==0.60.0
numpy==1.26.4
nvidia-cublas-cu12==12.4.5.8
nvidia-cuda-cupti-cu12==12.4.127
nvidia-cuda-nvrtc-cu12==12.4.127
nvidia-cuda-runtime-cu12==12.4.127
nvidia-cudnn-cu12==9.1.0.70
nvidia-cufft-cu12==11.2.1.3
nvidia-curand-cu12==10.3.5.147
nvidia-cusolver-cu12==11.6.1.9
nvidia-cusparse-cu12==12.3.1.170
nvidia-ml-py==12.570.86
nvidia-nccl-cu12==2.21.5
nvidia-nvjitlink-cu12==12.4.127
nvidia-nvtx-cu12==12.4.127
nvtx==0.2.11
openai==1.67.0
opencensus==0.11.4
opencensus-context==0.1.3
opencv-python-headless==4.11.0.86
orjson==3.10.15
outlines==0.1.11
outlines_core==0.1.26
packaging==24.2
pandas==2.2.3
parso==0.8.4
partial-json-parser==0.2.1.1.post5
peft==0.15.0
performer-pytorch==1.1.4
pexpect==4.9.0
pillow==11.0.0
platformdirs==4.3.7
pluggy==1.5.0
pre_commit==4.2.0
prometheus-fastapi-instrumentator==7.1.0
prometheus_client==0.21.1
prompt_toolkit==3.0.50
propcache==0.3.0
proto-plus==1.26.1
protobuf==6.30.1
psutil==7.0.0
ptyprocess==0.7.0
pure_eval==0.2.3
py-cpuinfo==9.0.0
py-spy==0.4.0
pyarrow==19.0.1
pyasn1==0.6.1
pyasn1_modules==0.4.1
pybind11==2.13.6
pycountry==24.6.1
pydantic==2.10.6
pydantic_core==2.27.2
Pygments==2.19.1
pyparsing==3.2.1
pytest==8.3.5
pytest-asyncio==0.25.3
python-dateutil==2.9.0.post0
python-dotenv==1.0.1
python-json-logger==3.3.0
python-multipart==0.0.20
pytorch-triton-rocm==3.1.0
pytz==2025.1
PyYAML==6.0.2
pyzmq==26.3.0
ray==2.43.0
redis==5.2.1
referencing==0.36.2
regex==2024.11.6
requests==2.32.3
rich==13.9.4
rich-toolkit==0.13.2
rpds-py==0.23.1
rsa==4.7.2
runai-model-streamer==0.11.0
runai-model-streamer-s3==0.11.0
s3transfer==0.11.4
safetensors==0.5.3
scipy==1.15.2
seaborn==0.13.2
sentencepiece==0.2.0
setproctitle==1.3.5
setuptools-scm==8.2.1
sgl-kernel==0.0.5.post3
-e git+ssh://git@github.com/DeepAuto-AI/sglang.git@9c7103012e0391147e43c18e137e58e535793f3f#egg=sglang&subdirectory=python
shellingham==1.5.4
six==1.17.0
smart-open==7.1.0
sniffio==1.3.1
stack-data==0.6.3
starlette==0.46.1
sympy==1.13.1
tensorizer==2.9.2
tiktoken==0.9.0
tokenizers==0.21.1
tomli==2.2.1
torch==2.5.1+rocm6.2
torchao==0.9.0
torchaudio==2.5.1+rocm6.2
torchvision==0.20.1+rocm6.2
tqdm==4.67.1
traitlets==5.14.3
transformers==4.48.3
triton==3.1.0
typer==0.15.2
typing_extensions==4.12.2
tzdata==2025.1
urllib3==2.3.0
uvicorn==0.34.0
uvloop==0.21.0
virtualenv==20.29.3
# Editable install with no version control (vllm==0.7.2)
-e /root/library/.venv/lib/python3.10/site-packages
watchfiles==1.0.4
wcwidth==0.2.13
websockets==15.0.1
wrapt==1.17.2
xformers==0.0.28.post3
xgrammar==0.1.16
xxhash==3.5.0
yarl==1.18.3
zipp==3.21.0
```

</details>

<details>
<summary>env result</summary>

```bash
USER=root
SSH_CLIENT=216.165.12.11 50942 22
SHLVL=1
HOME=/root
MOTD_SHOWN=pam
OLDPWD=/root/library/hip-attention
SSL_CERT_FILE=/usr/lib/ssl/certs/ca-certificates.crt
LOGNAME=root
_=/usr/bin/env
PATH=/root/library/.venv/bin:/root/.vscode-server/cli/servers/Stable-2fc07b811f760549dab9be9d2bedd06c51dfcb9a/server/bin/remote-cli:/opt/cache/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/opt/ompi/bin:/opt/ucx/bin:/root/.vscode-server/extensions/ms-python.debugpy-2025.4.1-linux-x64/bundled/scripts/noConfigScripts
SSL_CERT_DIR=/usr/lib/ssl/certs
SHELL=/usr/bin/zsh
PWD=/root/library/sglang
SSH_CONNECTION=216.165.12.11 50942 192.168.208.3 22
ZSH=/root/.oh-my-zsh
PAGER=more
LSCOLORS=Gxfxcxdxbxegedabagacad
LS_COLORS=rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.webp=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:
_P9K_SSH_TTY=/dev/pts/14
BROWSER=/root/.vscode-server/cli/servers/Stable-2fc07b811f760549dab9be9d2bedd06c51dfcb9a/server/bin/helpers/browser.sh
TERM_PROGRAM=vscode
TERM_PROGRAM_VERSION=1.98.1
LANG=en_US.UTF-8
COLORTERM=truecolor
GIT_ASKPASS=/root/.vscode-server/cli/servers/Stable-2fc07b811f760549dab9be9d2bedd06c51dfcb9a/server/extensions/git/dist/askpass.sh
VSCODE_GIT_ASKPASS_NODE=/root/.vscode-server/cli/servers/Stable-2fc07b811f760549dab9be9d2bedd06c51dfcb9a/server/node
VSCODE_GIT_ASKPASS_EXTRA_ARGS=
VSCODE_GIT_ASKPASS_MAIN=/root/.vscode-server/cli/servers/Stable-2fc07b811f760549dab9be9d2bedd06c51dfcb9a/server/extensions/git/dist/askpass-main.js
VSCODE_GIT_IPC_HANDLE=/tmp/vscode-git-a5d2413697.sock
PYDEVD_DISABLE_FILE_VALIDATION=1
VSCODE_DEBUGPY_ADAPTER_ENDPOINTS=/root/.vscode-server/extensions/ms-python.debugpy-2025.4.1-linux-x64/.noConfigDebugAdapterEndpoints/endpoint-ada4da49c61d1c48.txt
BUNDLED_DEBUGPY_PATH=/root/.vscode-server/extensions/ms-python.debugpy-2025.4.1-linux-x64/bundled/libs/debugpy
VSCODE_IPC_HOOK_CLI=/tmp/vscode-ipc-9edc00be-922c-4b07-b5ef-26ed9663f824.sock
VSCODE_INJECTION=1
VSCODE_NONCE=e096aff3-9f4d-47aa-a415-c0f280f7f420
ZDOTDIR=/root
USER_ZDOTDIR=/root
TERM=xterm-256color
P9K_TTY=old
_P9K_TTY=/dev/pts/14
P9K_SSH=1
LC_CTYPE=en_US.UTF-8
LC_ALL=en_US.UTF-8
LANGUAGE=en_US.UTF-8
VIRTUAL_ENV=/root/library/.venv
PS1=(.venv) ${$((_p9k_on_expand()))+}%{${_p9k__raw_msg-}${_p9k__raw_msg::=}%}${(e)_p9k_t[7]}${_p9k__1-${${:-${_p9k__d::=0}${_p9k__rprompt::=${_p9k__1r-${${:-${_p9k__bg::=NONE}${_p9k__i::=0}${_p9k__sss::=}}+}${${:-${P9K_CONTENT::=}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=8}}${_p9k__n:=${${(M)${:-x$_p9k__bg}:#x(|0)}:+10}}${_p9k__n:=11}${_p9k__c::="${P9K}}${_p9k__e::=${${_p9k__1r:+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}0}}}+}${${_p9k__e:#00}:+${_p9k_t[$_p9k__n]/<_p9k__w>/$_p9k__w}${_p9k__c}%b%k%f${${:-${_p9k__w::=%b%k%f}${_p9k__sss::=%b%k%f}${_p9k__i::=1}${_p9k__bg::=}}+}}${${:-"${${(%):-%j}:#0}"}:+${${:-${P9K_CONTENT::=""}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=12}}${_p9k__n:=${${(M)${:-x$_p9k__bg}:#x(|0)}:+14}}${_p9k__n:=15}${_p9k__v::=}${_p9k__c::="${P9K_CONTENT}"}${_p9k__c::=${_p9k__c/}}${_p9k__e::=${${_p9k__1rbackground_jobs+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}1}}}+}${${_p9k__e:#00}:+${_p9k_t[$_p9k__n]/<_p9k__w>/$_p9k__w}${_p9k__v}${${(M)_p9k__e:#11}:+ }${_p9k__c}%b%k%F{070\}${${:-${_p9k__w::=%b%k%F{070\}}${_p9k__sss::=%b%k%F{070\}}${_p9k__i::=3}${_p9k__bg::=}}+}}}${${:-"${${(%):-%#}:#\#}"}:+${${:-${P9K_CONTENT::=%n@%m}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=16}}${_p9k__n:=${${(M)${:-x$_p9k__bg}:#x(|0)}:+18}}${_p9k__n}}${_p9k__e::=${${_p9k__1rcontext+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}0}}}+}${${_p9k__e:#00}:+${_p9k_t[$_p9k__n]/<_p9k__w>/$_p9k__w}${_p9k__c}%b%k%F{180\}${${:-${_p9k__w::=%b%k%F{180\}}${_p9k__sss::=%b%k%F{180\}}${_p9k__i::=31}${_p9k__bg::=}}+}}}${${:-"${${(%):-%#}:#\%}"}:+${${:-${P9K_CONTENT::=%B%n@%m}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=20}}${_p9k__n:=${${(M)${:-x$_p9k__bg}:#x(|0)}:+22}}${_p9k__n:=23}${_p9k__c::="${P9K_CONTENT}"}${_p}}${_p9k__e::=${${_p9k__1rcontext+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}0}}}+}${${_p9k__e:#00}:+${_p9k_t[$_p9k__n]/<_p9k__w>/$_p9k__w}${_p9k__c}%b%k%F{178\}${${:-${_p9k__w::=%b%k%F{178\}}${_p9k__sss::=%b%k%F{178\}}${_p9k__i::=31}${_p9k__bg::=}}+}}}${${:-${P9K_CONTENT::=15:31:56}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=24}}${_p9k__n:=${${(M)${:-x$_p9k__}}${_p9k__e::=${${_p9k__1rtime+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}0}}}+}${${_p9k__e:#00}:+${_p9k_t[$_p9k__n]/<_p9k__w>/$_p9k__w}${_p9k__c}%b%k%F{066\}${${:-${_p9k__w::=%b%k%F{066\}}${_p9k__sss::=%b%k%F{066\}}${_p9k__i::=46}${_p9k__bg::=}}+}}$_p9k__sss%b%k%f}}${_p9k__lprompt::=${_p9k__1l-${${:-${_p9k__bg::=NONE}${_p9k__i::=0}${_p9k__sss::=%f}}+}${${:-${P9K_CONTENT::="%{d%}${:-"%B%F{039}"}${(Q)${:-"\\~"}}${:-"%b%k%F{031}"}/${${${_p9k__d:#-*}:+library}:-${:-"%F{103}"}l${:-"%b%k%F{031}"}${$((_p9k__d+=6))+}}/${:-"%B%F{039}"}vllm${:-"%b%k%F{031}"}%{d%}"}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=28}}${_p9k__n:=${${(M)${:-x}:#x($_p9k__bg|${_p9k__bg:-0})}:+30}}${_p9k__n:=31}${_p9k__c::="${P9K_CONTENT}"}${_p9k__c::=$}}${_p9k__e::=${${_p9k__1ldir+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}0}}}+}${${_p9k__e:#00}:+${${_p9k_t[$_p9k__n]/<_p9k__ss>/$_p9k__ss}/<_p9k__s>/$_p9k__s}${_p9k__c}%b%k%F{031\}${${:-${_p9k__s::=%F{\}}${_p9k__ss::= }${_p9k__sss::=%F{\}}${_p9k__i::=1}${_p9k__bg::=}}+}}${(e)_p9k__vcs}${${:-"${${:-$_p9k__keymap.$_p9k__zle_state}:#(vicmd.*|vivis.*|vivli.*|*.*overwrite*)}"}:+${${:-${P9K_CONTENT::=❯}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=92}}${_p9k__n:=${${(M)${:-x}:#x($_p9k__bg|${_p9k__bg:-0})}:+94}}${_p9k__n:=95}${_p9k__c::="❯"}${_p9}}${_p9k__e::=${${_p9k__1lprompt_char+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}0}}}+}${${_p9k__e:#00}:+${${_p9k_t[$_p9k__n]/<_p9k__ss>/$_p9k__ss}/<_p9k__s>/$_p9k__s}${_p9k__c}%b%k%F{196\}${${:-${_p9k__s::=%F{\}}${_p9k__ss::= }${_p9k__sss::=%F{\}}${_p9k__i::=3}${_p9k__bg::=}}+}}}${${:-"${${:-$_p9k__keymap.$_p9k__zle_state}:#(vicmd.*|vivis.*|vivli.*|*.*insert*)}"}:+${${:-${P9K_CONTENT::=▶}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=96}}${_p9k__n:=${${(M)${:-x}:#x($_p9k__bg|${_p9k__bg:-0})}:+98}}${_p9k__n:=99}${_p9k__c::="▶"}${_p9k__c::=${}}${_p9k__e::=${${_p9k__1lprompt_char+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}0}}}+}${${_p9k__e:#00}:+${${_p9k_t[$_p9k__n]/<_p9k__ss>/$_p9k__ss}/<_p9k__s>/$_p9k__s}${_p9k__c}%b%k%F{196\}${${:-${_p9k__s::=%F{\}}${_p9k__ss::= }${_p9k__sss::=%F{\}}${_p9k__i::=3}${_p9k__bg::=}}+}}}${${:-"${(M)${:-$_p9k__keymap$_p9k__region_active}:#vicmd0}"}:+${${:-${P9K_CONTENT::=❮}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=100}}${_p9k__n:=${${(M)${:-x}:#x($_p9k__b}}${_p9k__e::=${${_p9k__1lprompt_char+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}0}}}+}${${_p9k__e:#00}:+${${_p9k_t[$_p9k__n]/<_p9k__ss>/$_p9k__ss}/<_p9k__s>/$_p9k__s}${_p9k__c}%b%k%F{196\}${${:-${_p9k__s::=%F{\}}${_p9k__ss::= }${_p9k__sss::=%F{\}}${_p9k__i::=3}${_p9k__bg::=}}+}}}${${:-"${(M)${:-$_p9k__keymap$_p9k__region_active}:#(vicmd1|vivis?|vivli?)}"}:+${${:-${P9K_CONTENT::=Ⅴ}${_p9k__n::=}${${${_p9k__bg:-0}:#NONE}:-${_p9k__n::=104}}${_p9k__n:=${${(M)${:-x}:#x($_p9k__bg|${_p9k__bg:-0})}:+106}}${_p9k__n:=107}${_p9k__c::="V"}${_p9k__c::=${_p9k_}}${_p9k__e::=${${_p9k__1lprompt_char+00}:-${${(%):-$_p9k__c%1(l.1.0)}[-1]}0}}}+}${${_p9k__e:#00}:+${${_p9k_t[$_p9k__n]/<_p9k__ss>/$_p9k__ss}/<_p9k__s>/$_p9k__s}${_p9k__c}%b%k%F{196\}${${:-${_p9k__s::=%F{\}}${_p9k__ss::= }${_p9k__sss::=%F{\}}${_p9k__i::=3}${_p9k__bg::=}}+}}}%b%k$_p9k__sss%b%k%f${:-" %b%k%f"}}}}+}${(e)_p9k_t[6]}${${_p9k__h::=100.5}+}${${_p9k__d::=$((_p9k__m-_p9k__h))}+}${_p9k__lprompt/\%\{d\%\}*\%\{d\%\}/${_p9k__1ldir-${:-"%B%F{039}"}${(Q)${:-"\\~"}}${:-"%b%k%F{031}"}/${${${_p9k__d:#-*}:+library}:-${:-"%F{103}"}l${:-"%b%k%F{031}"}${$((_p9k__d+=6))+}}/${:-"%B%F{039}"}vllm${:-"%b%k%F{031}"}}}${${_p9k__m::=$((_p9k__d+_p9k__h))}+}}${${COLUMNS::=$_p9k__clm}+}%{%}
VIRTUAL_ENV_PROMPT=(.venv) 
PYTORCH_ROCM_ARCH=gfx90a;gfx942
HF_HOME=/workspace/.cache/huggingface
```

</details>

# How to setup

1. Install the latest ROCm SDK
2. Install HiP Attention from source
3. Install SGlang from the source

Tested git hash: `9c7103012e0391147e43c18e137e58e535793f3f`, DeepAuto-AI/sglang
```bash
# in sgl-kernel
python setup_rocm.py install
# In the repository root
pip install -e "python[all_hip]"
```

4. Install vLLM from source (override installed vLLM)

```bash
# in branch v0.7.2 
pip install setuptools-scm
pip install -r requirements/rocm.txt
pip install /opt/rocm/share/amd_smi
export PYTORCH_ROCM_ARCH="gfx90a;gfx942"
# change the ROCm path to match your SDK.
CMAKE_PREFIX_PATH=/opt/rocm-6.3.1 python setup.py develop
```

5. Install HIP-python

```bash
# in branch release/rocm-rel-6.3.3
# this is installed by hip-attention, so remove it first
pip uninstall cuda-python
git clone git@github.com:ROCm/hip-python.git
cd hip-python
./build.sh --hip --cuda --post-clean
# in hip-python
pip install hip_python-6.3.3.541.31-cp310-cp310-linux_x86_64.whl
# in hip-python-as-cuda
pip install hip_python_as_cuda-6.3.3.541.31-cp310-cp310-linux_x86_64.whl
```

# Tested Commands

```bash
# without offloading
HIP_DISABLE_FLASHDECODE=1 python -m sglang.launch_server --host 0.0.0.0 --port 3232 --model-path meta-llama/Llama-3.1-8B-Instruct --kv-cache-dtype auto --tp-size 1 --mem-fraction-static 0.8 --chunked-prefill-size 32768 --max-prefill-tokens 32768 --cuda-graph-bs 1 --context-length 1024000 --max-total-tokens 1024000 --max-running-request 1 --enable-hip-attention --hip-attention-config '{"mask_refresh_interval": [96, 24, 8]}' --allow-auto-truncate

# with offloading
HIP_DISABLE_FLASHDECODE=1 python -m sglang.launch_server --host 0.0.0.0 --port 3232 --model-path meta-llama/Llama-3.1-8B-Instruct --kv-cache-dtype auto --tp-size 1 --mem-fraction-static 0.8 --chunked-prefill-size 32768 --max-prefill-tokens 32768 --cuda-graph-bs 1 2 4 --context-length 1024000 --max-total-tokens 1024000 --max-running-request 1 --enable-hip-attention --hip-attention-config '{"mask_refresh_interval": [96, 24, 8]}' --allow-auto-truncate --enable-hip-offload
```

# Limitations

- Flash Decode is not working due to a compiler error. Therefore, single-batch decoding throughput might be lower than expected. I will work on this in future PR.
- Block sizes and kernel arguments are not carefully tuned. The performance might not be optimal in MI300X. Need to be fixed in future PR.
- In the original SGLang code, when you turn on the AMD HIP, the SGL forces the framework to capture the large size of batch sizes. This will cause a memory allocation issue. Therefore, it should be fixed on the SGL side. I made a hotfix in our repository (DeepAuto-AI/sglang:feat/rocm). `--cuda-graph-max-bs` will be also useful.
- Multi GPU has not been tested yet.