### PR TITLE
Move jagged for-loop to lib

### DIFF
--- a/src/hip_attn/v1_2/model_offload_cache.py
+++ b/src/hip_attn/v1_2/model_offload_cache.py
@@ -3,7 +3,7 @@ import math
 import os
 import threading
 import time
-from typing import Any, Dict, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import torch
@@ -160,10 +160,64 @@ class HiPModelOffloadCache:
     def get_fetched_prefix_kv_buffer(
         self,
         layer_id: int,
-        batch_id: int,
+        batch_id: Optional[int] = None,
         # you need to pass KV for extend
-        cache_k: Tensor,
-        cache_v: Tensor,
+        cache_k: Optional[Tensor] = None,
+        cache_v: Optional[Tensor] = None,
+        extend_seq_lens: Optional[Tensor] = None,
+        extend_seq_lens_cpu: Optional[List[int]] = None,
+    ) -> Tuple[
+        Union[Tensor, List[Tensor]], Union[Tensor, List[Tensor]], Union[Any, List[Any]]
+    ]:
+
+        if batch_id is not None:
+            return self._get_fetched_prefix_kv_buffer_single(
+                layer_id=layer_id,
+                batch_id=batch_id,
+                cache_k=cache_k,
+                cache_v=cache_v,
+            )
+
+        else:
+            k_chunks = []
+            v_chunks = []
+            offloading_metadata_list = []
+
+            start_len = 0
+            for idx_batch, seq_len in enumerate(extend_seq_lens_cpu):
+                if seq_len > 0:  # Skip empty sequences
+                    k_chunk, v_chunk, offloading_metadata = (
+                        self._get_fetched_prefix_kv_buffer_single(
+                            layer_id,
+                            idx_batch,
+                            cache_k=cache_k[start_len : start_len + seq_len].unsqueeze(
+                                0
+                            ),
+                            cache_v=cache_v[start_len : start_len + seq_len].unsqueeze(
+                                0
+                            ),
+                        )
+                    )
+                    k_chunks.append(k_chunk)
+                    v_chunks.append(v_chunk)
+                    offloading_metadata_list.append(offloading_metadata)
+
+                else:
+                    k_chunks.append(None)
+                    v_chunks.append(None)
+                    offloading_metadata_list.append(None)
+
+                start_len += seq_len
+
+            return k_chunks, v_chunks, offloading_metadata_list
+
+    def _get_fetched_prefix_kv_buffer_single(
+        self,
+        layer_id: int,
+        batch_id: Optional[int] = None,
+        # you need to pass KV for extend
+        cache_k: Optional[Tensor] = None,
+        cache_v: Optional[Tensor] = None,
     ) -> Tuple[Tensor, Tensor, Any]:
         # return cache_k, cache_v
 

--- a/src/hip_attn/v1_2/paged_hip.py
+++ b/src/hip_attn/v1_2/paged_hip.py
@@ -62,6 +62,140 @@ def forward_paged_hip(
     diag_sliding_window_indices: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, HiPAttentionOutputMetadata]:
 
+    if is_prefill:
+        # Handle jagged inputs
+
+        # Output tensor
+        o = torch.empty_like(query)
+
+        start_len = 0
+        decoding_reqs = []
+        decoding_reqs_positions = []
+        for idx_batch, seq_len in enumerate(forward_batch.extend_seq_lens_cpu):
+            if seq_len == 0:  # Skip empty sequences
+                decoding_reqs.append(idx_batch)
+                decoding_reqs_positions.append(start_len)
+
+            else:
+                if not self.is_kv_cache_offload_enabled:
+                    k_chunk = v_chunk = None
+                    offloading_metadata = None
+
+                else:  # Offloading enabled
+                    k_chunk, v_chunk, offloading_metadata = (
+                        forward_batch.token_to_kv_pool.get_fetched_prefix_kv_buffer(
+                            layer_id=layer_id,
+                            batch_id=idx_batch,
+                            cache_k=k[start_len : start_len + seq_len].unsqueeze(0),
+                            cache_v=v[start_len : start_len + seq_len].unsqueeze(0),
+                        )
+                    )
+                    offload_cache = k_cache = v_cache = None
+
+                o_req, _ = _forward_paged_hip_validate(
+                    query=query[start_len : start_len + seq_len],
+                    sm_scale=sm_scale,
+                    batch_size=1,
+                    k_cache=k_cache,
+                    v_cache=v_cache,
+                    offload_cache=offload_cache,
+                    positions=positions[start_len : start_len + seq_len],
+                    seq_lens=seq_lens[idx_batch : idx_batch + 1],
+                    req_to_tokens=req_to_tokens,
+                    req_pool_indices=req_pool_indices[idx_batch : idx_batch + 1],
+                    rope_cos=rope_cos,
+                    rope_sin=rope_sin,
+                    rope_range=rope_range,
+                    layer_id=layer_id,
+                    logit_cap=logit_cap,
+                    orig_context_len=orig_context_len,
+                    max_context_len=max_context_len,
+                    is_prefill=is_prefill,
+                    hip_config=hip_config,
+                    cached_metadata=cached_metadata,
+                    k=k,
+                    v=v,
+                    online_update_cache=online_update_cache,
+                    offloading_metadata=offloading_metadata,
+                    is_decode=is_decode,
+                    query_for_mask=query_for_mask,
+                    diag_sliding_window_indices=diag_sliding_window_indices,
+                )
+
+                o[start_len : start_len + seq_len] = o_req
+
+            start_len += seq_len
+
+        assert len(decoding_reqs) == 0
+
+        o = o.view(-1, layer.tp_q_head_num * layer.head_dim)
+
+        metadata_new = None
+
+    else:
+        o, metadata_new = _forward_paged_hip_validate(
+            query=query,
+            sm_scale=sm_scale,
+            batch_size=batch_size,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            offload_cache=offload_cache,
+            positions=positions,
+            seq_lens=seq_lens,
+            req_to_tokens=req_to_tokens,
+            req_pool_indices=req_pool_indices,
+            rope_cos=rope_cos,
+            rope_sin=rope_sin,
+            rope_range=rope_range,
+            layer_id=layer_id,
+            logit_cap=logit_cap,
+            orig_context_len=orig_context_len,
+            max_context_len=max_context_len,
+            is_prefill=is_prefill,
+            hip_config=hip_config,
+            cached_metadata=cached_metadata,
+            k=k,
+            v=v,
+            online_update_cache=online_update_cache,
+            offloading_metadata=offloading_metadata,
+            is_decode=is_decode,
+            query_for_mask=query_for_mask,
+            diag_sliding_window_indices=diag_sliding_window_indices,
+        )
+
+    return o, metadata_new
+
+
+def _forward_paged_hip_validate(
+    query: torch.Tensor,
+    sm_scale: float,
+    batch_size: int,
+    k_cache: Optional[torch.Tensor],
+    v_cache: Optional[torch.Tensor],
+    offload_cache: Optional[HiPOffloadCache],
+    positions: torch.Tensor,
+    seq_lens: torch.Tensor,
+    req_to_tokens: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    rope_cos: Optional[torch.Tensor],
+    rope_sin: Optional[torch.Tensor],
+    layer_id: int,
+    logit_cap: float,
+    orig_context_len: int,
+    max_context_len: int,
+    is_prefill: bool,
+    hip_config: HiPAttentionConfig,
+    rope_range: Optional[tuple[int, int]] = None,
+    cached_metadata: Optional[HiPAttentionOutputMetadata] = None,
+    k: Optional[torch.Tensor] = None,
+    v: Optional[torch.Tensor] = None,
+    online_update_cache: bool = False,
+    offloading_metadata: Any = None,
+    is_decode: bool = False,
+    query_for_mask: Optional[torch.Tensor] = None,
+    diag_sliding_window_indices: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, HiPAttentionOutputMetadata]:
+
     if k is not None:
         # BUG: this padding is neccesary to match non offload scenario. why?
         pad_size = max_context_len
@@ -146,6 +280,7 @@ def forward_paged_hip(
                 req_pool_indices=req_pool_indices,
                 rope_cos=rope_cos,
                 rope_sin=rope_sin,
+                rope_range=rope_range,
                 layer_id=layer_id,
                 logit_cap=logit_cap,
                 orig_context_len=orig_context_len,
@@ -177,6 +312,7 @@ def forward_paged_hip(
                 req_pool_indices=req_pool_indices,
                 rope_cos=rope_cos,
                 rope_sin=rope_sin,
+                rope_range=rope_range,
                 layer_id=layer_id,
                 logit_cap=logit_cap,
                 orig_context_len=orig_context_len,
@@ -248,6 +384,7 @@ def forward_paged_hip(
                     req_pool_indices=req_pool_indices,
                     rope_cos=rope_cos,
                     rope_sin=rope_sin,
+                    rope_range=rope_range,
                     layer_id=layer_id,
                     logit_cap=logit_cap,
                     orig_context_len=orig_context_len,
@@ -278,6 +415,7 @@ def forward_paged_hip(
                     req_pool_indices=req_pool_indices,
                     rope_cos=rope_cos,
                     rope_sin=rope_sin,
+                    rope_range=rope_range,
                     layer_id=layer_id,
                     logit_cap=logit_cap,
                     orig_context_len=orig_context_len,

--- a/src/hip_attn/v1_2/paged_hip.py
+++ b/src/hip_attn/v1_2/paged_hip.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import Any, Optional
 
 import torch
@@ -49,53 +50,62 @@ def forward_paged_hip(
     logit_cap: float,
     orig_context_len: int,
     max_context_len: int,
-    is_prefill: bool,
     hip_config: HiPAttentionConfig,
     rope_range: Optional[tuple[int, int]] = None,
+    extend_seq_lens: Optional[torch.Tensor] = None,
+    extend_seq_lens_cpu: Optional[torch.Tensor] = None,
     cached_metadata: Optional[HiPAttentionOutputMetadata] = None,
     k: Optional[torch.Tensor] = None,
     v: Optional[torch.Tensor] = None,
     online_update_cache: bool = False,
     offloading_metadata: Any = None,
+    is_prefill: Optional[bool] = None,
     is_decode: bool = False,
     query_for_mask: Optional[torch.Tensor] = None,
     diag_sliding_window_indices: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, HiPAttentionOutputMetadata]:
 
-    if is_prefill:
+    if is_prefill is not None:
+        warnings.warn("is_prefill is deprecated. Use is_decode instead.")
+
+    if not is_decode and extend_seq_lens_cpu is not None:
         # Handle jagged inputs
+        is_kv_cache_offload_enabled = k is not None and v is not None
+        if is_kv_cache_offload_enabled:
+            assert isinstance(k, list) and isinstance(v, list)
+            assert isinstance(offloading_metadata, list)
+            offload_cache = k_cache = v_cache = None
 
         # Output tensor
         o = torch.empty_like(query)
+        metadata_new = cached_metadata
 
         start_len = 0
         decoding_reqs = []
         decoding_reqs_positions = []
-        for idx_batch, seq_len in enumerate(forward_batch.extend_seq_lens_cpu):
+        for idx_batch, seq_len in enumerate(extend_seq_lens_cpu):
             if seq_len == 0:  # Skip empty sequences
                 decoding_reqs.append(idx_batch)
                 decoding_reqs_positions.append(start_len)
 
             else:
-                if not self.is_kv_cache_offload_enabled:
+                if not is_kv_cache_offload_enabled:
                     k_chunk = v_chunk = None
-                    offloading_metadata = None
+                    offloading_metadata_curr = None
 
                 else:  # Offloading enabled
-                    k_chunk, v_chunk, offloading_metadata = (
-                        forward_batch.token_to_kv_pool.get_fetched_prefix_kv_buffer(
-                            layer_id=layer_id,
-                            batch_id=idx_batch,
-                            cache_k=k[start_len : start_len + seq_len].unsqueeze(0),
-                            cache_v=v[start_len : start_len + seq_len].unsqueeze(0),
-                        )
+                    k_chunk, v_chunk, offloading_metadata_curr = (
+                        k[idx_batch],
+                        v[idx_batch],
+                        offloading_metadata[idx_batch],
                     )
-                    offload_cache = k_cache = v_cache = None
 
                 o_req, _ = _forward_paged_hip_validate(
                     query=query[start_len : start_len + seq_len],
                     sm_scale=sm_scale,
                     batch_size=1,
+                    k=k_chunk,
+                    v=v_chunk,
                     k_cache=k_cache,
                     v_cache=v_cache,
                     offload_cache=offload_cache,
@@ -110,13 +120,10 @@ def forward_paged_hip(
                     logit_cap=logit_cap,
                     orig_context_len=orig_context_len,
                     max_context_len=max_context_len,
-                    is_prefill=is_prefill,
                     hip_config=hip_config,
                     cached_metadata=cached_metadata,
-                    k=k,
-                    v=v,
                     online_update_cache=online_update_cache,
-                    offloading_metadata=offloading_metadata,
+                    offloading_metadata=offloading_metadata_curr,
                     is_decode=is_decode,
                     query_for_mask=query_for_mask,
                     diag_sliding_window_indices=diag_sliding_window_indices,
@@ -127,10 +134,6 @@ def forward_paged_hip(
             start_len += seq_len
 
         assert len(decoding_reqs) == 0
-
-        o = o.view(-1, layer.tp_q_head_num * layer.head_dim)
-
-        metadata_new = None
 
     else:
         o, metadata_new = _forward_paged_hip_validate(
@@ -151,7 +154,6 @@ def forward_paged_hip(
             logit_cap=logit_cap,
             orig_context_len=orig_context_len,
             max_context_len=max_context_len,
-            is_prefill=is_prefill,
             hip_config=hip_config,
             cached_metadata=cached_metadata,
             k=k,
@@ -183,7 +185,6 @@ def _forward_paged_hip_validate(
     logit_cap: float,
     orig_context_len: int,
     max_context_len: int,
-    is_prefill: bool,
     hip_config: HiPAttentionConfig,
     rope_range: Optional[tuple[int, int]] = None,
     cached_metadata: Optional[HiPAttentionOutputMetadata] = None,
@@ -229,7 +230,7 @@ def _forward_paged_hip_validate(
 
     require_validation = offloading_metadata is not None
     if require_validation:
-        if is_prefill:
+        if not is_decode:
             k_pages, v_pages = offloading_metadata
         else:
             k_cache_valid, v_cache_valid = offloading_metadata
@@ -266,7 +267,7 @@ def _forward_paged_hip_validate(
     )
 
     if require_validation:
-        if is_prefill:
+        if not is_decode:
             o_req_valid, _ = _forward_paged_hip(
                 query=query,
                 sm_scale=sm_scale,


### PR DESCRIPTION
Currently, the prefill in sglang is done by running a for-loop along the batch axis. However, in the future, this might change.

So, I move the for-loop logic from sglang into the hip-attn library.

This change is backward-compatible.