### PR TITLE
Remove torch version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ classifiers = [
 ]
 dependencies = [
     # Required
-    "torch==2.5.1",
+    "torch",
+    "triton>=3.2.0",
     "setuptools",  # Required by triton amd backend
     "numba",
     "performer_pytorch",


### PR DESCRIPTION
Currently several CI tests on SGLang side fail (e.g. https://github.com/sgl-project/sglang/actions/runs/14160148913/job/39665768104?pr=3930) because hip-attn's torch version is fixed to 2.5.1. There is no need for this requirement, so I remove it. 