### PR TITLE
Initial support of Llama4

### DIFF
--- a/hip-research/src/hip_research/main/jobs/passkey.py
+++ b/hip-research/src/hip_research/main/jobs/passkey.py
@@ -95,10 +95,10 @@ def job_passkey(args, model, tokenizer, device):
         location = int(location / 0.2) / 5
 
         seq_len = input_ids.shape[1]
-        
+
         seq_lens.add(seq_len)
         locations.add(location)
-        
+
         accuracy_key = (seq_len, location)
         acc_sum, acc_count = accuracy.get(accuracy_key, (0, 0))
         for x, y in zip(truth, est):
@@ -120,12 +120,18 @@ def job_passkey(args, model, tokenizer, device):
         tqdm.write(
             f"current accuracy { {k: f'{v[0] / (v[1] + 1e-20)*100:.2f}' for k, v in accuracy.items()} } | {truth[0]}, {est[0]}"
         )
-    
+
     seq_lens = list(sorted(seq_lens))
     locations = list(sorted(locations))
-    
-    def to_acc(x): return x[0] / (x[1] + 1e-20) * 100
+
+    def to_acc(x):
+        return x[0] / (x[1] + 1e-20) * 100
+
     print(f'Loc.,{",".join(map(lambda x: str(x), seq_lens))}')
-    print(f'Avg.,{",".join([str(to_acc(accuracy[(seq_len,)])) for seq_len in seq_lens])}')
+    print(
+        f'Avg.,{",".join([str(to_acc(accuracy[(seq_len,)])) for seq_len in seq_lens])}'
+    )
     for location in locations:
-        print(f'{location},{",".join([str(to_acc(accuracy[(seq_len, location)])) for seq_len in seq_lens])}')
+        print(
+            f'{location},{",".join([str(to_acc(accuracy[(seq_len, location)])) for seq_len in seq_lens])}'
+        )

--- a/hip-research/src/hip_research/main/jobs/passkey.py
+++ b/hip-research/src/hip_research/main/jobs/passkey.py
@@ -18,7 +18,9 @@ def get_numbers(s, cnt):
 def job_passkey(args, model, tokenizer, device):
     dataset = Passkey(tokenizer, batch_size=args.batch_size)
 
-    accuracy = {}
+    accuracy = dict()
+    seq_lens = set()
+    locations = set()
 
     for j, (input_ids, target_ids) in enumerate(
         tqdm(dataset, dynamic_ncols=True, leave=False)
@@ -93,6 +95,10 @@ def job_passkey(args, model, tokenizer, device):
         location = int(location / 0.2) / 5
 
         seq_len = input_ids.shape[1]
+        
+        seq_lens.add(seq_len)
+        locations.add(location)
+        
         accuracy_key = (seq_len, location)
         acc_sum, acc_count = accuracy.get(accuracy_key, (0, 0))
         for x, y in zip(truth, est):
@@ -114,3 +120,12 @@ def job_passkey(args, model, tokenizer, device):
         tqdm.write(
             f"current accuracy { {k: f'{v[0] / (v[1] + 1e-20)*100:.2f}' for k, v in accuracy.items()} } | {truth[0]}, {est[0]}"
         )
+    
+    seq_lens = list(sorted(seq_lens))
+    locations = list(sorted(locations))
+    
+    def to_acc(x): return x[0] / (x[1] + 1e-20) * 100
+    print(f'Loc.,{",".join(map(lambda x: str(x), seq_lens))}')
+    print(f'Avg.,{",".join([str(to_acc(accuracy[(seq_len,)])) for seq_len in seq_lens])}')
+    for location in locations:
+        print(f'{location},{",".join([str(to_acc(accuracy[(seq_len, location)])) for seq_len in seq_lens])}')

--- a/hip-research/src/hip_research/main/scripts/throughput_benchmark.py
+++ b/hip-research/src/hip_research/main/scripts/throughput_benchmark.py
@@ -25,6 +25,7 @@ class RequestStatistics:
 def is_third_party(endpoint):
     return any([keyword in endpoint for keyword in ["together", "friendli"]])
 
+
 def stream_chat_completion(
     endpoint: str, messages, num_prefill: int, num_decode: int, num_concurrent: int
 ):
@@ -32,7 +33,7 @@ def stream_chat_completion(
         url = f"{endpoint}/flush_cache"
         requests.post(url)
 
-    if 'friendli' in endpoint:
+    if "friendli" in endpoint:
         url = f"{endpoint}/v1/completions"
     else:
         url = f"{endpoint}/v1/chat/completions"
@@ -41,10 +42,10 @@ def stream_chat_completion(
         "Content-Type": "application/json",
     }
     # Note the 'stream': True parameter
-    if 'friendli' in endpoint:
+    if "friendli" in endpoint:
         data = {
             "model": os.getenv("HIP_SGLANG_MODEL", "anything"),
-            "prompt": messages[-1]['content'],
+            "prompt": messages[-1]["content"],
             "temperature": 0.0,
             "max_tokens": num_decode,
             "min_tokens": num_decode,
@@ -119,16 +120,26 @@ def stream_chat_completion(
         num_returned=num_returned,
     )
 
+
 def shuffle(lst):
     import random
+
     random.shuffle(lst)
     return lst
+
 
 def get_random_passkey(tokenizer: transformers.LlamaTokenizer, seq_len: int):
     header = "There is a passkey hidden inside a lot of irrelevant text. Find the passkey and memorize it. I will quiz you about the the passkey."
     passkey = "HERE IS THE PASSKEY! The passkey is $000310$. $000310$ is the passkey. **the passkey is $000310$** LOOK BEHIND FOR PASSKEY"
     footer = "In previous text, you have seen the passkey. You had to remember that passkey. What was the passkey? Just answer the secret keyword without any verbal text."
-    filler = " ".join(shuffle("The grass is green. The sky is blue. The sun is yellow. Here we go. There and back again. ".split())) + " "
+    filler = (
+        " ".join(
+            shuffle(
+                "The grass is green. The sky is blue. The sun is yellow. Here we go. There and back again. ".split()
+            )
+        )
+        + " "
+    )
     len_filler = tokenizer(filler, return_tensors="pt").input_ids.shape[-1]
     num_filler = math.ceil(seq_len * 1024 / len_filler * 0.95)
 

--- a/hip-research/src/hip_research/main/scripts/throughput_benchmark.py
+++ b/hip-research/src/hip_research/main/scripts/throughput_benchmark.py
@@ -2,6 +2,7 @@ import argparse
 import itertools
 import json
 import math
+import os
 import time
 import traceback
 from dataclasses import dataclass
@@ -21,27 +22,45 @@ class RequestStatistics:
     num_returned: int
 
 
+def is_third_party(endpoint):
+    return any([keyword in endpoint for keyword in ["together", "friendli"]])
+
 def stream_chat_completion(
     endpoint: str, messages, num_prefill: int, num_decode: int, num_concurrent: int
 ):
-    url = f"{endpoint}/flush_cache"
-    requests.post(url)
+    if not is_third_party(endpoint):
+        url = f"{endpoint}/flush_cache"
+        requests.post(url)
 
-    url = f"{endpoint}/v1/chat/completions"
+    if 'friendli' in endpoint:
+        url = f"{endpoint}/v1/completions"
+    else:
+        url = f"{endpoint}/v1/chat/completions"
     headers = {
-        "Authorization": f"Bearer sk-dummy",
+        "Authorization": f"Bearer {os.getenv('HIP_SGLANG_APIKEY', 'sk-dummy')}",
         "Content-Type": "application/json",
     }
     # Note the 'stream': True parameter
-    data = {
-        "model": "anything",
-        "messages": messages,
-        "temperature": 0.0,
-        "max_tokens": num_decode,
-        "min_tokens": num_decode,
-        "stream": True,
-        "n": num_concurrent,
-    }
+    if 'friendli' in endpoint:
+        data = {
+            "model": os.getenv("HIP_SGLANG_MODEL", "anything"),
+            "prompt": messages[-1]['content'],
+            "temperature": 0.0,
+            "max_tokens": num_decode,
+            "min_tokens": num_decode,
+            "stream": True,
+            "n": num_concurrent,
+        }
+    else:
+        data = {
+            "model": os.getenv("HIP_SGLANG_MODEL", "anything"),
+            "messages": messages,
+            "temperature": 0.0,
+            "max_tokens": num_decode,
+            "min_tokens": num_decode,
+            "stream": True,
+            "n": num_concurrent,
+        }
 
     is_decode = False
     timestamp_start = time.time()
@@ -100,12 +119,16 @@ def stream_chat_completion(
         num_returned=num_returned,
     )
 
+def shuffle(lst):
+    import random
+    random.shuffle(lst)
+    return lst
 
 def get_random_passkey(tokenizer: transformers.LlamaTokenizer, seq_len: int):
     header = "There is a passkey hidden inside a lot of irrelevant text. Find the passkey and memorize it. I will quiz you about the the passkey."
     passkey = "HERE IS THE PASSKEY! The passkey is $000310$. $000310$ is the passkey. **the passkey is $000310$** LOOK BEHIND FOR PASSKEY"
     footer = "In previous text, you have seen the passkey. You had to remember that passkey. What was the passkey? Just answer the secret keyword without any verbal text."
-    filler = "The grass is green. The sky is blue. The sun is yellow. Here we go. There and back again. "
+    filler = " ".join(shuffle("The grass is green. The sky is blue. The sun is yellow. Here we go. There and back again. ".split())) + " "
     len_filler = tokenizer(filler, return_tensors="pt").input_ids.shape[-1]
     num_filler = math.ceil(seq_len * 1024 / len_filler * 0.95)
 
@@ -157,10 +180,11 @@ def benchmark(
         leave=False,
     ):
         example = get_random_example(tokenizer, dataset, seq_len)
-        # run warmup
-        stream_chat_completion(
-            endpoint, example, seq_len * 1024, decode_len, num_concurrent
-        )
+        if not is_third_party(endpoint):
+            # run warmup
+            stream_chat_completion(
+                endpoint, example, seq_len * 1024, decode_len, num_concurrent
+            )
         # sample
         result = stream_chat_completion(
             endpoint, example, seq_len * 1024, decode_len, num_concurrent
@@ -185,7 +209,7 @@ def benchmark(
 
 # Example usage:
 if __name__ == "__main__":
-    seed()
+    seed(seed=int(time.time() * 100000) % 100000)
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--endpoint", type=str)

--- a/hip-research/src/hip_research/models/sglang_model.py
+++ b/hip-research/src/hip_research/models/sglang_model.py
@@ -1,3 +1,4 @@
+import os
 import requests
 from transformers import AutoTokenizer
 
@@ -68,8 +69,11 @@ class SglangModel:
 
             response = requests.post(
                 f"{self.endpoint}/v1/chat/completions",
+                headers={
+                    'Authorization': f'Bearer {os.getenv("HIP_SGLANG_APIKEY", "sk-dummy")}'
+                },
                 json={
-                    "model": "anything",
+                    "model": os.getenv('HIP_SGLANG_MODEL', 'anything'),
                     "messages": input_text,
                     "max_tokens": max_tokens,
                     "top_p": 0.000000000001,

--- a/hip-research/src/hip_research/models/sglang_model.py
+++ b/hip-research/src/hip_research/models/sglang_model.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 from transformers import AutoTokenizer
 
@@ -70,10 +71,10 @@ class SglangModel:
             response = requests.post(
                 f"{self.endpoint}/v1/chat/completions",
                 headers={
-                    'Authorization': f'Bearer {os.getenv("HIP_SGLANG_APIKEY", "sk-dummy")}'
+                    "Authorization": f'Bearer {os.getenv("HIP_SGLANG_APIKEY", "sk-dummy")}'
                 },
                 json={
-                    "model": os.getenv('HIP_SGLANG_MODEL', 'anything'),
+                    "model": os.getenv("HIP_SGLANG_MODEL", "anything"),
                     "messages": input_text,
                     "max_tokens": max_tokens,
                     "top_p": 0.000000000001,

--- a/src/hip_attn/v1_2/attention_decode_bsa.py
+++ b/src/hip_attn/v1_2/attention_decode_bsa.py
@@ -398,7 +398,7 @@ def _fwd_kernel_stage1(
         kv_blocks_per_split = 0
         split_kv_block_start = 0
         split_kv_block_end = 0
-    
+
     e_max = tl.full([BLOCK_H, 1], -float("inf"), dtype=tl.float32)  # m_i
     e_sum = tl.full([BLOCK_H, 1], 1.0, dtype=tl.float32)  # l_i
     acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
@@ -822,7 +822,7 @@ def _fwd_kernel_stage1(
                 pass
 
     # process sink tokens
-    if (sink_token_size > 0):
+    if sink_token_size > 0:
         sink_tokens_per_split = tl.cdiv(sink_token_size, NUM_SINK_KV_SPLITS)
         split_sink_start = sink_tokens_per_split * sink_split_kv_id
         split_sink_end = tl.minimum(

--- a/src/hip_attn/v1_2/attention_decode_bsa.py
+++ b/src/hip_attn/v1_2/attention_decode_bsa.py
@@ -388,118 +388,54 @@ def _fwd_kernel_stage1(
     if BK <= 0:
         range_start = 0
         range_end = 0
-
-    kv_blocks_per_split = tl.cdiv(BK, NUM_SPARSE_KV_SPLITS)
-    split_kv_block_start = kv_blocks_per_split * split_kv_id
-    split_kv_block_end = tl.minimum(split_kv_block_start + kv_blocks_per_split, BK)
-
+    
     e_max = tl.full([BLOCK_H, 1], -float("inf"), dtype=tl.float32)  # m_i
     e_sum = tl.full([BLOCK_H, 1], 1.0, dtype=tl.float32)  # l_i
     acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
 
-    if (split_kv_block_end > split_kv_block_start) and True:
-        for i_bk in range(split_kv_block_start, split_kv_block_end, BLOCK_BK):
-            idx_bk = i_bk + tl.arange(0, BLOCK_BK)  # [BLOCK_BK]
-            mask_bk = (range_start <= idx_bk) & (
-                idx_bk < tl.minimum(range_start + BK, range_end)
-            )  # [BLOCK_BK]
+    if BK > 0:
+        kv_blocks_per_split = tl.cdiv(BK, NUM_SPARSE_KV_SPLITS)
+        split_kv_block_start = kv_blocks_per_split * split_kv_id
+        split_kv_block_end = tl.minimum(split_kv_block_start + kv_blocks_per_split, BK)
 
-            if (range_start <= i_bk + BLOCK_BK) & (i_bk < range_end):
-                idx_tsrc_start = tl.load(
-                    INDICES
-                    + cur_flattened_batch.to(tl.int64) * stride_indices_b
-                    + 0 * stride_indices_bdst
-                    + idx_bk * stride_indices_bk,
-                    mask=mask_bk & (cur_head_begin < q_head_num),
-                    other=0,
+        if (split_kv_block_end > split_kv_block_start) and True:
+            for i_bk in range(split_kv_block_start, split_kv_block_end, BLOCK_BK):
+                idx_bk = i_bk + tl.arange(0, BLOCK_BK)  # [BLOCK_BK]
+                mask_bk = (range_start <= idx_bk) & (
+                    idx_bk < tl.minimum(range_start + BK, range_end)
                 )  # [BLOCK_BK]
-                idx_tsrc_start = tl.where(mask_bk, idx_tsrc_start, MAX_TSRC + 1)
-                idx_tsrc = idx_tsrc_start[:, None] + tl.arange(0, BLOCK_SIZE_K)[None, :]
-                idx_tsrc = tl.reshape(idx_tsrc, (BLOCK_BK * BLOCK_SIZE_K))
-                mask_tsrc_from_bk = mask_bk[:, None] & tl.full(
-                    (1, BLOCK_SIZE_K), 1, dtype=tl.int1
-                )
-                mask_tsrc_from_bk = tl.reshape(
-                    mask_tsrc_from_bk, (BLOCK_BK * BLOCK_SIZE_K)
-                )
-                mask_tsrc = (
-                    ((MAX_TSRC * 0) <= idx_tsrc)
-                    & (idx_tsrc < (MAX_TSRC * 1))
-                    & mask_tsrc_from_bk
-                )
-                idx_tsrc = idx_tsrc % MAX_TSRC  # [BLOCK_BK * BLOCK_SIZE_K]
-                mask_tsrc = (
-                    (sink_token_size <= idx_tsrc)
-                    & (idx_tsrc < cur_batch_seq_len)
-                    & mask_tsrc
-                )
 
-                keys_0 = load_tokens(
-                    K,
-                    stride_k_bsz,
-                    stride_k_tsrc,
-                    stride_k_head,
-                    stride_k_hid,
-                    USING_PAGES,
-                    PAGE_SIZE,
-                    K_CACHE,
-                    stride_k_cache_page,
-                    stride_k_cache_offset,
-                    stride_k_cache_kv_head,
-                    stride_k_cache_hid,
-                    BLOCK_TABLE,
-                    stride_block_table_bsz,
-                    stride_block_table_page,
-                    CACHE_SEQ_LENS,
-                    stride_cache_seq_lens_b,
-                    USING_OFFLOAD_CACHE,
-                    OFFLOAD_CACHE_KV_PACKED,
-                    GPU_BANK_COUNT,
-                    False,
-                    OFFLOAD_CACHE_UVM_METADATA,
-                    stride_offload_cache_uvm_metadata_token,
-                    stride_offload_cache_uvm_metadata_k,
-                    OFFLOAD_CACHE_GPU_GLOBAL_METADATA,
-                    stride_offload_cache_gpu_global_metadata_k,
-                    stride_offload_cache_gpu_global_metadata_pad,
-                    OFFLOAD_CACHE_GPU_BANK,
-                    stride_offload_cache_gpu_bank_token,
-                    stride_offload_cache_gpu_bank_hid,
-                    OFFLOAD_CACHE_GPU_METADATA,
-                    stride_offload_cache_gpu_metadata_token,
-                    stride_offload_cache_gpu_metadata_k,
-                    OFFLOAD_CACHE_GPU_TABLE,
-                    stride_offload_cache_gpu_table_head_kv,
-                    stride_offload_cache_gpu_table_token,
-                    strdie_offload_cache_gpu_table_k,
-                    ACCESS_COUNTER,
-                    stride_access_counter_bsz,
-                    stride_access_counter_head_kv,
-                    stride_access_counter_tsrc,
-                    CACHE_MISS_COUNTER,
-                    stride_cache_miss_counter_bsz,
-                    stride_cache_miss_counter_head_kv,
-                    stride_cache_miss_counter_tsrc,
-                    cur_batch,
-                    idx_tsrc[None, :],
-                    cur_kv_head,
-                    offs_d_0[:, None],
-                    mask_tsrc[None, :],
-                    q_head_num // kv_group_num,
-                    BLOCK_SIZE_K,
-                    BLOCK_DMODEL_0,
-                    Lk,
-                    IS_BSA=True,
-                    UPDATE_CACHE=UPDATE_CACHE,
-                    V_CACHE=V_CACHE,
-                    stride_v_cache_page=stride_v_cache_page,
-                    stride_v_cache_offset=stride_v_cache_offset,
-                    stride_v_cache_kv_head=stride_v_cache_kv_head,
-                    stride_v_cache_hid=stride_v_cache_hid,
-                )
+                if (range_start <= i_bk + BLOCK_BK) & (i_bk < range_end):
+                    idx_tsrc_start = tl.load(
+                        INDICES
+                        + cur_flattened_batch.to(tl.int64) * stride_indices_b
+                        + 0 * stride_indices_bdst
+                        + idx_bk * stride_indices_bk,
+                        mask=mask_bk & (cur_head_begin < q_head_num),
+                        other=0,
+                    )  # [BLOCK_BK]
+                    idx_tsrc_start = tl.where(mask_bk, idx_tsrc_start, MAX_TSRC + 1)
+                    idx_tsrc = idx_tsrc_start[:, None] + tl.arange(0, BLOCK_SIZE_K)[None, :]
+                    idx_tsrc = tl.reshape(idx_tsrc, (BLOCK_BK * BLOCK_SIZE_K))
+                    mask_tsrc_from_bk = mask_bk[:, None] & tl.full(
+                        (1, BLOCK_SIZE_K), 1, dtype=tl.int1
+                    )
+                    mask_tsrc_from_bk = tl.reshape(
+                        mask_tsrc_from_bk, (BLOCK_BK * BLOCK_SIZE_K)
+                    )
+                    mask_tsrc = (
+                        ((MAX_TSRC * 0) <= idx_tsrc)
+                        & (idx_tsrc < (MAX_TSRC * 1))
+                        & mask_tsrc_from_bk
+                    )
+                    idx_tsrc = idx_tsrc % MAX_TSRC  # [BLOCK_BK * BLOCK_SIZE_K]
+                    mask_tsrc = (
+                        (sink_token_size <= idx_tsrc)
+                        & (idx_tsrc < cur_batch_seq_len)
+                        & mask_tsrc
+                    )
 
-                if BLOCK_DMODEL_1 > 0:
-                    keys_1 = load_tokens(
+                    keys = load_tokens(
                         K,
                         stride_k_bsz,
                         stride_k_tsrc,
@@ -548,11 +484,10 @@ def _fwd_kernel_stage1(
                         cur_batch,
                         idx_tsrc[None, :],
                         cur_kv_head,
-                        offs_d_1[:, None],
+                        offs_d[:, None],
                         mask_tsrc[None, :],
                         q_head_num // kv_group_num,
                         BLOCK_SIZE_K,
-                        BLOCK_DMODEL_1,
                         Lk,
                         IS_BSA=True,
                         UPDATE_CACHE=UPDATE_CACHE,
@@ -562,12 +497,9 @@ def _fwd_kernel_stage1(
                         stride_v_cache_kv_head=stride_v_cache_kv_head,
                         stride_v_cache_hid=stride_v_cache_hid,
                     )
-                else:
-                    keys_1 = None
 
-                if USING_EXTEND and NEED_APPLY_ROPE:
-                    if rope_range_begin < BLOCK_DMODEL_0:
-                        keys_rot_0 = load_tokens(
+                    if USING_EXTEND and NEED_APPLY_ROPE:
+                        keys_rot = load_tokens(
                             K,
                             stride_k_bsz,
                             stride_k_tsrc,
@@ -616,11 +548,10 @@ def _fwd_kernel_stage1(
                             cur_batch,
                             idx_tsrc[None, :],
                             cur_kv_head,
-                            rope_rot_idx_0[:, None],
+                            ((offs_d[:, None] + Lk // 2) % Lk),
                             mask_tsrc[None, :],
                             q_head_num // kv_group_num,
                             BLOCK_SIZE_K,
-                            BLOCK_DMODEL_0,
                             Lk,
                             IS_BSA=True,
                             UPDATE_CACHE=UPDATE_CACHE,
@@ -631,189 +562,110 @@ def _fwd_kernel_stage1(
                             stride_v_cache_hid=stride_v_cache_hid,
                         )
                     else:
-                        keys_rot_0 = None
+                        keys_rot = None
 
-                    if BLOCK_DMODEL_1 > 0:
-                        keys_rot_1 = load_tokens(
-                            K,
-                            stride_k_bsz,
-                            stride_k_tsrc,
-                            stride_k_head,
-                            stride_k_hid,
-                            USING_PAGES,
-                            PAGE_SIZE,
-                            K_CACHE,
-                            stride_k_cache_page,
-                            stride_k_cache_offset,
-                            stride_k_cache_kv_head,
-                            stride_k_cache_hid,
-                            BLOCK_TABLE,
-                            stride_block_table_bsz,
-                            stride_block_table_page,
-                            CACHE_SEQ_LENS,
-                            stride_cache_seq_lens_b,
-                            USING_OFFLOAD_CACHE,
-                            OFFLOAD_CACHE_KV_PACKED,
-                            GPU_BANK_COUNT,
-                            False,
-                            OFFLOAD_CACHE_UVM_METADATA,
-                            stride_offload_cache_uvm_metadata_token,
-                            stride_offload_cache_uvm_metadata_k,
-                            OFFLOAD_CACHE_GPU_GLOBAL_METADATA,
-                            stride_offload_cache_gpu_global_metadata_k,
-                            stride_offload_cache_gpu_global_metadata_pad,
-                            OFFLOAD_CACHE_GPU_BANK,
-                            stride_offload_cache_gpu_bank_token,
-                            stride_offload_cache_gpu_bank_hid,
-                            OFFLOAD_CACHE_GPU_METADATA,
-                            stride_offload_cache_gpu_metadata_token,
-                            stride_offload_cache_gpu_metadata_k,
-                            OFFLOAD_CACHE_GPU_TABLE,
-                            stride_offload_cache_gpu_table_head_kv,
-                            stride_offload_cache_gpu_table_token,
-                            strdie_offload_cache_gpu_table_k,
-                            ACCESS_COUNTER,
-                            stride_access_counter_bsz,
-                            stride_access_counter_head_kv,
-                            stride_access_counter_tsrc,
-                            CACHE_MISS_COUNTER,
-                            stride_cache_miss_counter_bsz,
-                            stride_cache_miss_counter_head_kv,
-                            stride_cache_miss_counter_tsrc,
-                            cur_batch,
-                            idx_tsrc[None, :],
-                            cur_kv_head,
-                            rope_rot_idx_1[:, None],
-                            mask_tsrc[None, :],
-                            q_head_num // kv_group_num,
-                            BLOCK_SIZE_K,
-                            BLOCK_DMODEL_1,
-                            Lk,
-                            IS_BSA=True,
-                            UPDATE_CACHE=UPDATE_CACHE,
-                            V_CACHE=V_CACHE,
-                            stride_v_cache_page=stride_v_cache_page,
-                            stride_v_cache_offset=stride_v_cache_offset,
-                            stride_v_cache_kv_head=stride_v_cache_kv_head,
-                            stride_v_cache_hid=stride_v_cache_hid,
-                        )
-                    else:
-                        keys_rot_1 = None
+                    values = load_tokens(
+                        V,
+                        stride_v_bsz,
+                        stride_v_tsrc,
+                        stride_v_head,
+                        stride_v_hid,
+                        USING_PAGES,
+                        PAGE_SIZE,
+                        V_CACHE,
+                        stride_v_cache_page,
+                        stride_v_cache_offset,
+                        stride_v_cache_kv_head,
+                        stride_v_cache_hid,
+                        BLOCK_TABLE,
+                        stride_block_table_bsz,
+                        stride_block_table_page,
+                        CACHE_SEQ_LENS,
+                        stride_cache_seq_lens_b,
+                        USING_OFFLOAD_CACHE,
+                        OFFLOAD_CACHE_KV_PACKED,
+                        GPU_BANK_COUNT,
+                        True,
+                        OFFLOAD_CACHE_UVM_METADATA,
+                        stride_offload_cache_uvm_metadata_token,
+                        stride_offload_cache_uvm_metadata_k,
+                        OFFLOAD_CACHE_GPU_GLOBAL_METADATA,
+                        stride_offload_cache_gpu_global_metadata_k,
+                        stride_offload_cache_gpu_global_metadata_pad,
+                        OFFLOAD_CACHE_GPU_BANK,
+                        stride_offload_cache_gpu_bank_token,
+                        stride_offload_cache_gpu_bank_hid,
+                        OFFLOAD_CACHE_GPU_METADATA,
+                        stride_offload_cache_gpu_metadata_token,
+                        stride_offload_cache_gpu_metadata_k,
+                        OFFLOAD_CACHE_GPU_TABLE,
+                        stride_offload_cache_gpu_table_head_kv,
+                        stride_offload_cache_gpu_table_token,
+                        strdie_offload_cache_gpu_table_k,
+                        ACCESS_COUNTER,
+                        stride_access_counter_bsz,
+                        stride_access_counter_head_kv,
+                        stride_access_counter_tsrc,
+                        CACHE_MISS_COUNTER,
+                        stride_cache_miss_counter_bsz,
+                        stride_cache_miss_counter_head_kv,
+                        stride_cache_miss_counter_tsrc,
+                        cur_batch,
+                        idx_tsrc[:, None],
+                        cur_kv_head,
+                        offs_dv[None, :],
+                        mask_tsrc[:, None],
+                        q_head_num // kv_group_num,
+                        BLOCK_SIZE_K,
+                        Lv,
+                        IS_BSA=True,
+                        UPDATE_CACHE=UPDATE_CACHE,
+                        V_CACHE=K_CACHE,
+                        stride_v_cache_page=stride_k_cache_page,
+                        stride_v_cache_offset=stride_k_cache_offset,
+                        stride_v_cache_kv_head=stride_k_cache_kv_head,
+                        stride_v_cache_hid=stride_k_cache_hid,
+                    )
 
+                    acc, e_sum, e_max = block_sparse_attention_cuda_step(
+                        q,  # FIXME: q is [BLOCK_H, BLOCK_DMODEL]: the first axis is head, not time
+                        keys,
+                        keys_rot,
+                        values,
+                        idx_tsrc,
+                        mask_tsrc,
+                        tl.zeros([1], dtype=tl.int32),
+                        tl.full((1,), 1, dtype=tl.int1),
+                        acc,
+                        e_sum,
+                        e_max,
+                        sliding_window_size,
+                        sink_token_size,
+                        (range_end - range_start) * BLOCK_SIZE_K,  # mask_k
+                        True,
+                        False,
+                        LOGIT_SOFTCAP,
+                        USING_EXTEND,
+                        NEED_APPLY_ROPE,
+                        COS,
+                        stride_cos_t,
+                        stride_cos_hid,
+                        SIN,
+                        stride_sin_t,
+                        stride_sin_hid,
+                        model_context_length,
+                        idx_bk + sink_token_size // BLOCK_SIZE_K,
+                        cur_batch_seq_len,
+                        offs_d,
+                        IS_CAUSAL,
+                        Lk,
+                        BLOCK_SIZE_Q,
+                        BLOCK_BK * BLOCK_SIZE_K,
+                        BLOCK_SIZE_K,
+                        EXTEND_BACKEND=EXTEND_BACKEND,
+                    )
                 else:
-                    keys_rot_0 = None
-                    keys_rot_1 = None
-
-                values = load_tokens(
-                    V,
-                    stride_v_bsz,
-                    stride_v_tsrc,
-                    stride_v_head,
-                    stride_v_hid,
-                    USING_PAGES,
-                    PAGE_SIZE,
-                    V_CACHE,
-                    stride_v_cache_page,
-                    stride_v_cache_offset,
-                    stride_v_cache_kv_head,
-                    stride_v_cache_hid,
-                    BLOCK_TABLE,
-                    stride_block_table_bsz,
-                    stride_block_table_page,
-                    CACHE_SEQ_LENS,
-                    stride_cache_seq_lens_b,
-                    USING_OFFLOAD_CACHE,
-                    OFFLOAD_CACHE_KV_PACKED,
-                    GPU_BANK_COUNT,
-                    True,
-                    OFFLOAD_CACHE_UVM_METADATA,
-                    stride_offload_cache_uvm_metadata_token,
-                    stride_offload_cache_uvm_metadata_k,
-                    OFFLOAD_CACHE_GPU_GLOBAL_METADATA,
-                    stride_offload_cache_gpu_global_metadata_k,
-                    stride_offload_cache_gpu_global_metadata_pad,
-                    OFFLOAD_CACHE_GPU_BANK,
-                    stride_offload_cache_gpu_bank_token,
-                    stride_offload_cache_gpu_bank_hid,
-                    OFFLOAD_CACHE_GPU_METADATA,
-                    stride_offload_cache_gpu_metadata_token,
-                    stride_offload_cache_gpu_metadata_k,
-                    OFFLOAD_CACHE_GPU_TABLE,
-                    stride_offload_cache_gpu_table_head_kv,
-                    stride_offload_cache_gpu_table_token,
-                    strdie_offload_cache_gpu_table_k,
-                    ACCESS_COUNTER,
-                    stride_access_counter_bsz,
-                    stride_access_counter_head_kv,
-                    stride_access_counter_tsrc,
-                    CACHE_MISS_COUNTER,
-                    stride_cache_miss_counter_bsz,
-                    stride_cache_miss_counter_head_kv,
-                    stride_cache_miss_counter_tsrc,
-                    cur_batch,
-                    idx_tsrc[:, None],
-                    cur_kv_head,
-                    offs_dv[None, :],
-                    mask_tsrc[:, None],
-                    q_head_num // kv_group_num,
-                    BLOCK_SIZE_K,
-                    BLOCK_DV,
-                    Lv,
-                    IS_BSA=True,
-                    UPDATE_CACHE=UPDATE_CACHE,
-                    V_CACHE=K_CACHE,
-                    stride_v_cache_page=stride_k_cache_page,
-                    stride_v_cache_offset=stride_k_cache_offset,
-                    stride_v_cache_kv_head=stride_k_cache_kv_head,
-                    stride_v_cache_hid=stride_k_cache_hid,
-                )
-
-                acc, e_sum, e_max = block_sparse_attention_cuda_step(
-                    q_0,  # FIXME: q is [BLOCK_H, BLOCK_DMODEL]: the first axis is head, not time
-                    q_1,
-                    keys_0,
-                    keys_1,
-                    keys_rot_0,
-                    keys_rot_1,
-                    values,
-                    idx_tsrc,
-                    mask_tsrc,
-                    tl.zeros([1], dtype=tl.int32),
-                    tl.full((1,), 1, dtype=tl.int1),
-                    acc,
-                    e_sum,
-                    e_max,
-                    sliding_window_size,
-                    sink_token_size,
-                    (range_end - range_start) * BLOCK_SIZE_K,  # mask_k
-                    True,
-                    False,
-                    LOGIT_SOFTCAP,
-                    USING_EXTEND,
-                    NEED_APPLY_ROPE,
-                    COS,
-                    stride_cos_t,
-                    stride_cos_hid,
-                    SIN,
-                    stride_sin_t,
-                    stride_sin_hid,
-                    rope_range_begin,
-                    rope_range_end,
-                    rope_is_neox_style,
-                    model_context_length,
-                    idx_bk + sink_token_size // BLOCK_SIZE_K,
-                    cur_batch_seq_len,
-                    offs_d_0,
-                    offs_d_1,
-                    IS_CAUSAL,
-                    Lk,
-                    BLOCK_SIZE_Q,
-                    BLOCK_BK * BLOCK_SIZE_K,
-                    BLOCK_SIZE_K,
-                    EXTEND_BACKEND=EXTEND_BACKEND,
-                )
-            else:
-                pass
+                    pass
 
     # process sink tokens
     sink_tokens_per_split = tl.cdiv(sink_token_size, NUM_SINK_KV_SPLITS)

--- a/src/hip_attn/v1_2/attention_decode_bsa.py
+++ b/src/hip_attn/v1_2/attention_decode_bsa.py
@@ -389,54 +389,123 @@ def _fwd_kernel_stage1(
     if BK <= 0:
         range_start = 0
         range_end = 0
-    
-    e_max = tl.full([BLOCK_H, 1], -float("inf"), dtype=tl.float32)  # m_i
-    e_sum = tl.full([BLOCK_H, 1], 1.0, dtype=tl.float32)  # l_i
-    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
 
     if BK > 0:
         kv_blocks_per_split = tl.cdiv(BK, NUM_SPARSE_KV_SPLITS)
         split_kv_block_start = kv_blocks_per_split * split_kv_id
         split_kv_block_end = tl.minimum(split_kv_block_start + kv_blocks_per_split, BK)
+    else:
+        kv_blocks_per_split = 0
+        split_kv_block_start = 0
+        split_kv_block_end = 0
+    
+    e_max = tl.full([BLOCK_H, 1], -float("inf"), dtype=tl.float32)  # m_i
+    e_sum = tl.full([BLOCK_H, 1], 1.0, dtype=tl.float32)  # l_i
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
 
-        if (split_kv_block_end > split_kv_block_start) and True:
-            for i_bk in range(split_kv_block_start, split_kv_block_end, BLOCK_BK):
-                idx_bk = i_bk + tl.arange(0, BLOCK_BK)  # [BLOCK_BK]
-                mask_bk = (range_start <= idx_bk) & (
-                    idx_bk < tl.minimum(range_start + BK, range_end)
+    if ((BK > 0) & (split_kv_block_end > split_kv_block_start)) and True:
+        for i_bk in range(split_kv_block_start, split_kv_block_end, BLOCK_BK):
+            idx_bk = i_bk + tl.arange(0, BLOCK_BK)  # [BLOCK_BK]
+            mask_bk = (range_start <= idx_bk) & (
+                idx_bk < tl.minimum(range_start + BK, range_end)
+            )  # [BLOCK_BK]
+
+            if (range_start <= i_bk + BLOCK_BK) & (i_bk < range_end):
+                idx_tsrc_start = tl.load(
+                    INDICES
+                    + cur_flattened_batch.to(tl.int64) * stride_indices_b
+                    + 0 * stride_indices_bdst
+                    + idx_bk * stride_indices_bk,
+                    mask=mask_bk & (cur_head_begin < q_head_num),
+                    other=0,
                 )  # [BLOCK_BK]
+                idx_tsrc_start = tl.where(mask_bk, idx_tsrc_start, MAX_TSRC + 1)
+                idx_tsrc = idx_tsrc_start[:, None] + tl.arange(0, BLOCK_SIZE_K)[None, :]
+                idx_tsrc = tl.reshape(idx_tsrc, (BLOCK_BK * BLOCK_SIZE_K))
+                mask_tsrc_from_bk = mask_bk[:, None] & tl.full(
+                    (1, BLOCK_SIZE_K), 1, dtype=tl.int1
+                )
+                mask_tsrc_from_bk = tl.reshape(
+                    mask_tsrc_from_bk, (BLOCK_BK * BLOCK_SIZE_K)
+                )
+                mask_tsrc = (
+                    ((MAX_TSRC * 0) <= idx_tsrc)
+                    & (idx_tsrc < (MAX_TSRC * 1))
+                    & mask_tsrc_from_bk
+                )
+                idx_tsrc = idx_tsrc % MAX_TSRC  # [BLOCK_BK * BLOCK_SIZE_K]
+                mask_tsrc = (
+                    (sink_token_size <= idx_tsrc)
+                    & (idx_tsrc < cur_batch_seq_len)
+                    & mask_tsrc
+                )
 
-                if (range_start <= i_bk + BLOCK_BK) & (i_bk < range_end):
-                    idx_tsrc_start = tl.load(
-                        INDICES
-                        + cur_flattened_batch.to(tl.int64) * stride_indices_b
-                        + 0 * stride_indices_bdst
-                        + idx_bk * stride_indices_bk,
-                        mask=mask_bk & (cur_head_begin < q_head_num),
-                        other=0,
-                    )  # [BLOCK_BK]
-                    idx_tsrc_start = tl.where(mask_bk, idx_tsrc_start, MAX_TSRC + 1)
-                    idx_tsrc = idx_tsrc_start[:, None] + tl.arange(0, BLOCK_SIZE_K)[None, :]
-                    idx_tsrc = tl.reshape(idx_tsrc, (BLOCK_BK * BLOCK_SIZE_K))
-                    mask_tsrc_from_bk = mask_bk[:, None] & tl.full(
-                        (1, BLOCK_SIZE_K), 1, dtype=tl.int1
-                    )
-                    mask_tsrc_from_bk = tl.reshape(
-                        mask_tsrc_from_bk, (BLOCK_BK * BLOCK_SIZE_K)
-                    )
-                    mask_tsrc = (
-                        ((MAX_TSRC * 0) <= idx_tsrc)
-                        & (idx_tsrc < (MAX_TSRC * 1))
-                        & mask_tsrc_from_bk
-                    )
-                    idx_tsrc = idx_tsrc % MAX_TSRC  # [BLOCK_BK * BLOCK_SIZE_K]
-                    mask_tsrc = (
-                        (sink_token_size <= idx_tsrc)
-                        & (idx_tsrc < cur_batch_seq_len)
-                        & mask_tsrc
-                    )
+                keys_0 = load_tokens(
+                    K,
+                    stride_k_bsz,
+                    stride_k_tsrc,
+                    stride_k_head,
+                    stride_k_hid,
+                    USING_PAGES,
+                    PAGE_SIZE,
+                    K_CACHE,
+                    stride_k_cache_page,
+                    stride_k_cache_offset,
+                    stride_k_cache_kv_head,
+                    stride_k_cache_hid,
+                    BLOCK_TABLE,
+                    stride_block_table_bsz,
+                    stride_block_table_page,
+                    CACHE_SEQ_LENS,
+                    stride_cache_seq_lens_b,
+                    USING_OFFLOAD_CACHE,
+                    OFFLOAD_CACHE_KV_PACKED,
+                    GPU_BANK_COUNT,
+                    False,
+                    OFFLOAD_CACHE_UVM_METADATA,
+                    stride_offload_cache_uvm_metadata_token,
+                    stride_offload_cache_uvm_metadata_k,
+                    OFFLOAD_CACHE_GPU_GLOBAL_METADATA,
+                    stride_offload_cache_gpu_global_metadata_k,
+                    stride_offload_cache_gpu_global_metadata_pad,
+                    OFFLOAD_CACHE_GPU_BANK,
+                    stride_offload_cache_gpu_bank_token,
+                    stride_offload_cache_gpu_bank_hid,
+                    OFFLOAD_CACHE_GPU_METADATA,
+                    stride_offload_cache_gpu_metadata_token,
+                    stride_offload_cache_gpu_metadata_k,
+                    OFFLOAD_CACHE_GPU_TABLE,
+                    stride_offload_cache_gpu_table_head_kv,
+                    stride_offload_cache_gpu_table_token,
+                    strdie_offload_cache_gpu_table_k,
+                    ACCESS_COUNTER,
+                    stride_access_counter_bsz,
+                    stride_access_counter_head_kv,
+                    stride_access_counter_tsrc,
+                    CACHE_MISS_COUNTER,
+                    stride_cache_miss_counter_bsz,
+                    stride_cache_miss_counter_head_kv,
+                    stride_cache_miss_counter_tsrc,
+                    cur_batch,
+                    idx_tsrc[None, :],
+                    cur_kv_head,
+                    offs_d_0[:, None],
+                    mask_tsrc[None, :],
+                    q_head_num // kv_group_num,
+                    BLOCK_SIZE_K,
+                    BLOCK_DMODEL_0,
+                    Lk,
+                    IS_BSA=True,
+                    UPDATE_CACHE=UPDATE_CACHE,
+                    V_CACHE=V_CACHE,
+                    stride_v_cache_page=stride_v_cache_page,
+                    stride_v_cache_offset=stride_v_cache_offset,
+                    stride_v_cache_kv_head=stride_v_cache_kv_head,
+                    stride_v_cache_hid=stride_v_cache_hid,
+                )
 
-                    keys = load_tokens(
+                if BLOCK_DMODEL_1 > 0:
+                    keys_1 = load_tokens(
                         K,
                         stride_k_bsz,
                         stride_k_tsrc,
@@ -485,10 +554,11 @@ def _fwd_kernel_stage1(
                         cur_batch,
                         idx_tsrc[None, :],
                         cur_kv_head,
-                        offs_d[:, None],
+                        offs_d_1[:, None],
                         mask_tsrc[None, :],
                         q_head_num // kv_group_num,
                         BLOCK_SIZE_K,
+                        BLOCK_DMODEL_1,
                         Lk,
                         IS_BSA=True,
                         UPDATE_CACHE=UPDATE_CACHE,
@@ -498,9 +568,12 @@ def _fwd_kernel_stage1(
                         stride_v_cache_kv_head=stride_v_cache_kv_head,
                         stride_v_cache_hid=stride_v_cache_hid,
                     )
+                else:
+                    keys_1 = None
 
-                    if USING_EXTEND and NEED_APPLY_ROPE:
-                        keys_rot = load_tokens(
+                if USING_EXTEND and NEED_APPLY_ROPE:
+                    if rope_range_begin < BLOCK_DMODEL_0:
+                        keys_rot_0 = load_tokens(
                             K,
                             stride_k_bsz,
                             stride_k_tsrc,
@@ -549,10 +622,11 @@ def _fwd_kernel_stage1(
                             cur_batch,
                             idx_tsrc[None, :],
                             cur_kv_head,
-                            ((offs_d[:, None] + Lk // 2) % Lk),
+                            rope_rot_idx_0[:, None],
                             mask_tsrc[None, :],
                             q_head_num // kv_group_num,
                             BLOCK_SIZE_K,
+                            BLOCK_DMODEL_0,
                             Lk,
                             IS_BSA=True,
                             UPDATE_CACHE=UPDATE_CACHE,
@@ -563,117 +637,201 @@ def _fwd_kernel_stage1(
                             stride_v_cache_hid=stride_v_cache_hid,
                         )
                     else:
-                        keys_rot = None
+                        keys_rot_0 = None
 
-                    values = load_tokens(
-                        V,
-                        stride_v_bsz,
-                        stride_v_tsrc,
-                        stride_v_head,
-                        stride_v_hid,
-                        USING_PAGES,
-                        PAGE_SIZE,
-                        V_CACHE,
-                        stride_v_cache_page,
-                        stride_v_cache_offset,
-                        stride_v_cache_kv_head,
-                        stride_v_cache_hid,
-                        BLOCK_TABLE,
-                        stride_block_table_bsz,
-                        stride_block_table_page,
-                        CACHE_SEQ_LENS,
-                        stride_cache_seq_lens_b,
-                        USING_OFFLOAD_CACHE,
-                        OFFLOAD_CACHE_KV_PACKED,
-                        GPU_BANK_COUNT,
-                        True,
-                        OFFLOAD_CACHE_UVM_METADATA,
-                        stride_offload_cache_uvm_metadata_token,
-                        stride_offload_cache_uvm_metadata_k,
-                        OFFLOAD_CACHE_GPU_GLOBAL_METADATA,
-                        stride_offload_cache_gpu_global_metadata_k,
-                        stride_offload_cache_gpu_global_metadata_pad,
-                        OFFLOAD_CACHE_GPU_BANK,
-                        stride_offload_cache_gpu_bank_token,
-                        stride_offload_cache_gpu_bank_hid,
-                        OFFLOAD_CACHE_GPU_METADATA,
-                        stride_offload_cache_gpu_metadata_token,
-                        stride_offload_cache_gpu_metadata_k,
-                        OFFLOAD_CACHE_GPU_TABLE,
-                        stride_offload_cache_gpu_table_head_kv,
-                        stride_offload_cache_gpu_table_token,
-                        strdie_offload_cache_gpu_table_k,
-                        ACCESS_COUNTER,
-                        stride_access_counter_bsz,
-                        stride_access_counter_head_kv,
-                        stride_access_counter_tsrc,
-                        CACHE_MISS_COUNTER,
-                        stride_cache_miss_counter_bsz,
-                        stride_cache_miss_counter_head_kv,
-                        stride_cache_miss_counter_tsrc,
-                        cur_batch,
-                        idx_tsrc[:, None],
-                        cur_kv_head,
-                        offs_dv[None, :],
-                        mask_tsrc[:, None],
-                        q_head_num // kv_group_num,
-                        BLOCK_SIZE_K,
-                        Lv,
-                        IS_BSA=True,
-                        UPDATE_CACHE=UPDATE_CACHE,
-                        V_CACHE=K_CACHE,
-                        stride_v_cache_page=stride_k_cache_page,
-                        stride_v_cache_offset=stride_k_cache_offset,
-                        stride_v_cache_kv_head=stride_k_cache_kv_head,
-                        stride_v_cache_hid=stride_k_cache_hid,
-                    )
+                    if BLOCK_DMODEL_1 > 0:
+                        keys_rot_1 = load_tokens(
+                            K,
+                            stride_k_bsz,
+                            stride_k_tsrc,
+                            stride_k_head,
+                            stride_k_hid,
+                            USING_PAGES,
+                            PAGE_SIZE,
+                            K_CACHE,
+                            stride_k_cache_page,
+                            stride_k_cache_offset,
+                            stride_k_cache_kv_head,
+                            stride_k_cache_hid,
+                            BLOCK_TABLE,
+                            stride_block_table_bsz,
+                            stride_block_table_page,
+                            CACHE_SEQ_LENS,
+                            stride_cache_seq_lens_b,
+                            USING_OFFLOAD_CACHE,
+                            OFFLOAD_CACHE_KV_PACKED,
+                            GPU_BANK_COUNT,
+                            False,
+                            OFFLOAD_CACHE_UVM_METADATA,
+                            stride_offload_cache_uvm_metadata_token,
+                            stride_offload_cache_uvm_metadata_k,
+                            OFFLOAD_CACHE_GPU_GLOBAL_METADATA,
+                            stride_offload_cache_gpu_global_metadata_k,
+                            stride_offload_cache_gpu_global_metadata_pad,
+                            OFFLOAD_CACHE_GPU_BANK,
+                            stride_offload_cache_gpu_bank_token,
+                            stride_offload_cache_gpu_bank_hid,
+                            OFFLOAD_CACHE_GPU_METADATA,
+                            stride_offload_cache_gpu_metadata_token,
+                            stride_offload_cache_gpu_metadata_k,
+                            OFFLOAD_CACHE_GPU_TABLE,
+                            stride_offload_cache_gpu_table_head_kv,
+                            stride_offload_cache_gpu_table_token,
+                            strdie_offload_cache_gpu_table_k,
+                            ACCESS_COUNTER,
+                            stride_access_counter_bsz,
+                            stride_access_counter_head_kv,
+                            stride_access_counter_tsrc,
+                            CACHE_MISS_COUNTER,
+                            stride_cache_miss_counter_bsz,
+                            stride_cache_miss_counter_head_kv,
+                            stride_cache_miss_counter_tsrc,
+                            cur_batch,
+                            idx_tsrc[None, :],
+                            cur_kv_head,
+                            rope_rot_idx_1[:, None],
+                            mask_tsrc[None, :],
+                            q_head_num // kv_group_num,
+                            BLOCK_SIZE_K,
+                            BLOCK_DMODEL_1,
+                            Lk,
+                            IS_BSA=True,
+                            UPDATE_CACHE=UPDATE_CACHE,
+                            V_CACHE=V_CACHE,
+                            stride_v_cache_page=stride_v_cache_page,
+                            stride_v_cache_offset=stride_v_cache_offset,
+                            stride_v_cache_kv_head=stride_v_cache_kv_head,
+                            stride_v_cache_hid=stride_v_cache_hid,
+                        )
+                    else:
+                        keys_rot_1 = None
 
-                    acc, e_sum, e_max = block_sparse_attention_cuda_step(
-                        q,  # FIXME: q is [BLOCK_H, BLOCK_DMODEL]: the first axis is head, not time
-                        keys,
-                        keys_rot,
-                        values,
-                        idx_tsrc,
-                        mask_tsrc,
-                        tl.zeros([1], dtype=tl.int32),
-                        tl.full((1,), 1, dtype=tl.int1),
-                        acc,
-                        e_sum,
-                        e_max,
-                        sliding_window_size,
-                        sink_token_size,
-                        (range_end - range_start) * BLOCK_SIZE_K,  # mask_k
-                        True,
-                        False,
-                        LOGIT_SOFTCAP,
-                        USING_EXTEND,
-                        NEED_APPLY_ROPE,
-                        COS,
-                        stride_cos_t,
-                        stride_cos_hid,
-                        SIN,
-                        stride_sin_t,
-                        stride_sin_hid,
-                        model_context_length,
-                        idx_bk + sink_token_size // BLOCK_SIZE_K,
-                        cur_batch_seq_len,
-                        offs_d,
-                        IS_CAUSAL,
-                        Lk,
-                        BLOCK_SIZE_Q,
-                        BLOCK_BK * BLOCK_SIZE_K,
-                        BLOCK_SIZE_K,
-                        EXTEND_BACKEND=EXTEND_BACKEND,
-                    )
                 else:
-                    pass
+                    keys_rot_0 = None
+                    keys_rot_1 = None
+
+                values = load_tokens(
+                    V,
+                    stride_v_bsz,
+                    stride_v_tsrc,
+                    stride_v_head,
+                    stride_v_hid,
+                    USING_PAGES,
+                    PAGE_SIZE,
+                    V_CACHE,
+                    stride_v_cache_page,
+                    stride_v_cache_offset,
+                    stride_v_cache_kv_head,
+                    stride_v_cache_hid,
+                    BLOCK_TABLE,
+                    stride_block_table_bsz,
+                    stride_block_table_page,
+                    CACHE_SEQ_LENS,
+                    stride_cache_seq_lens_b,
+                    USING_OFFLOAD_CACHE,
+                    OFFLOAD_CACHE_KV_PACKED,
+                    GPU_BANK_COUNT,
+                    True,
+                    OFFLOAD_CACHE_UVM_METADATA,
+                    stride_offload_cache_uvm_metadata_token,
+                    stride_offload_cache_uvm_metadata_k,
+                    OFFLOAD_CACHE_GPU_GLOBAL_METADATA,
+                    stride_offload_cache_gpu_global_metadata_k,
+                    stride_offload_cache_gpu_global_metadata_pad,
+                    OFFLOAD_CACHE_GPU_BANK,
+                    stride_offload_cache_gpu_bank_token,
+                    stride_offload_cache_gpu_bank_hid,
+                    OFFLOAD_CACHE_GPU_METADATA,
+                    stride_offload_cache_gpu_metadata_token,
+                    stride_offload_cache_gpu_metadata_k,
+                    OFFLOAD_CACHE_GPU_TABLE,
+                    stride_offload_cache_gpu_table_head_kv,
+                    stride_offload_cache_gpu_table_token,
+                    strdie_offload_cache_gpu_table_k,
+                    ACCESS_COUNTER,
+                    stride_access_counter_bsz,
+                    stride_access_counter_head_kv,
+                    stride_access_counter_tsrc,
+                    CACHE_MISS_COUNTER,
+                    stride_cache_miss_counter_bsz,
+                    stride_cache_miss_counter_head_kv,
+                    stride_cache_miss_counter_tsrc,
+                    cur_batch,
+                    idx_tsrc[:, None],
+                    cur_kv_head,
+                    offs_dv[None, :],
+                    mask_tsrc[:, None],
+                    q_head_num // kv_group_num,
+                    BLOCK_SIZE_K,
+                    BLOCK_DV,
+                    Lv,
+                    IS_BSA=True,
+                    UPDATE_CACHE=UPDATE_CACHE,
+                    V_CACHE=K_CACHE,
+                    stride_v_cache_page=stride_k_cache_page,
+                    stride_v_cache_offset=stride_k_cache_offset,
+                    stride_v_cache_kv_head=stride_k_cache_kv_head,
+                    stride_v_cache_hid=stride_k_cache_hid,
+                )
+
+                acc, e_sum, e_max = block_sparse_attention_cuda_step(
+                    q_0,  # FIXME: q is [BLOCK_H, BLOCK_DMODEL]: the first axis is head, not time
+                    q_1,
+                    keys_0,
+                    keys_1,
+                    keys_rot_0,
+                    keys_rot_1,
+                    values,
+                    idx_tsrc,
+                    mask_tsrc,
+                    tl.zeros([1], dtype=tl.int32),
+                    tl.full((1,), 1, dtype=tl.int1),
+                    acc,
+                    e_sum,
+                    e_max,
+                    sliding_window_size,
+                    sink_token_size,
+                    (range_end - range_start) * BLOCK_SIZE_K,  # mask_k
+                    True,
+                    False,
+                    LOGIT_SOFTCAP,
+                    USING_EXTEND,
+                    NEED_APPLY_ROPE,
+                    COS,
+                    stride_cos_t,
+                    stride_cos_hid,
+                    SIN,
+                    stride_sin_t,
+                    stride_sin_hid,
+                    rope_range_begin,
+                    rope_range_end,
+                    rope_is_neox_style,
+                    model_context_length,
+                    idx_bk + sink_token_size // BLOCK_SIZE_K,
+                    cur_batch_seq_len,
+                    offs_d_0,
+                    offs_d_1,
+                    IS_CAUSAL,
+                    Lk,
+                    BLOCK_SIZE_Q,
+                    BLOCK_BK * BLOCK_SIZE_K,
+                    BLOCK_SIZE_K,
+                    EXTEND_BACKEND=EXTEND_BACKEND,
+                )
+            else:
+                pass
 
     # process sink tokens
-    sink_tokens_per_split = tl.cdiv(sink_token_size, NUM_SINK_KV_SPLITS)
-    split_sink_start = sink_tokens_per_split * sink_split_kv_id
-    split_sink_end = tl.minimum(
-        split_sink_start + sink_tokens_per_split, sink_token_size
-    )
+    if (sink_token_size > 0):
+        sink_tokens_per_split = tl.cdiv(sink_token_size, NUM_SINK_KV_SPLITS)
+        split_sink_start = sink_tokens_per_split * sink_split_kv_id
+        split_sink_end = tl.minimum(
+            split_sink_start + sink_tokens_per_split, sink_token_size
+        )
+    else:
+        sink_tokens_per_split = 0
+        split_sink_start = 0
+        split_sink_end = 0
     if (
         (sink_token_size > 0)
         & (0 <= sink_split_kv_id)

--- a/src/hip_attn/v1_2/attention_decode_bsa.py
+++ b/src/hip_attn/v1_2/attention_decode_bsa.py
@@ -241,6 +241,7 @@ def _fwd_kernel_stage1(
     BLOCK_DV: tl.constexpr,
     EXTEND_BACKEND: tl.constexpr,
     UPDATE_CACHE: tl.constexpr,
+    CHUNKED_SW: tl.constexpr,
 ):
     cur_batch = tl.program_id(0).to(tl.int64)
     cur_head_id = tl.program_id(1).to(tl.int64)
@@ -1469,6 +1470,7 @@ def _fwd_kernel_stage1(
                 BLOCK_BK * BLOCK_SIZE_K,
                 BLOCK_SIZE_K,
                 EXTEND_BACKEND=EXTEND_BACKEND,
+                CHUNKED_SW=CHUNKED_SW,
             )
 
     e_sum = tl.where(e_sum < 1e-20, 1e-20, e_sum)
@@ -1602,6 +1604,7 @@ def decode_block_sparse_attention_stage1(
         BLOCK_DV=BLOCK_DV,
         EXTEND_BACKEND=extend_backend,
         UPDATE_CACHE=offload_update_cache,
+        CHUNKED_SW=args.using_chunked_sliding_window,
     )
 
     return temp_attn_logits, NUM_TOTAL_KV_SPLITS

--- a/src/hip_attn/v1_2/attention_extend.py
+++ b/src/hip_attn/v1_2/attention_extend.py
@@ -217,9 +217,9 @@ def dual_stage_quadratic_hip_attention(
         args.rope_range = (0, HID)
 
     if args.rope_is_neox_style is None:
-        warnings.warn(
-            "Deprecated: Please specify `rope_is_neox_style`. Defaulting to True."
-        )
+        # warnings.warn(
+        #     "Deprecated: Please specify `rope_is_neox_style`. Defaulting to True."
+        # )
         args.rope_is_neox_style = True
 
     if args.rope_range[0] == 0 and args.rope_range[1] == HID:

--- a/src/hip_attn/v1_2/attention_extend.py
+++ b/src/hip_attn/v1_2/attention_extend.py
@@ -499,7 +499,7 @@ def dual_stage_quadratic_hip_attention(
                     k_dense = k[:, :TDST, :, :]
                     chunk_size = 1024
                     for t_start in range(0, TDST, chunk_size):
-                        k_slice = [:, t_start:t_start+chunk_size]
+                        k_slice = k_dense[:, t_start:t_start+chunk_size]
                 elif (
                     os.getenv("HIP_DEBUG_TOPKMEAN", "0") == "1"
                     and (i_stage == 0)

--- a/src/hip_attn/v1_2/attention_extend.py
+++ b/src/hip_attn/v1_2/attention_extend.py
@@ -43,6 +43,18 @@ def num_streaming_multiprocessor():
     return _NUM_STREAMING_MULTIPROCESSOR
 
 
+def get_block_sparse_backend(args: HiPAttentionArgs, q: torch.Tensor):
+    block_sparse_attention_backend = block_sparse_attention
+
+    # Use flashdecode
+    if (
+        (q.shape[1] == 1)
+        and (not os.environ.get("HIP_DISABLE_FLASHDECODE", "0") == "1")
+        and (not args.disable_flashdecode)
+    ):
+        block_sparse_attention_backend = decode_block_sparse_attention
+    return block_sparse_attention_backend
+
 @numba.njit(parallel=True)
 def render_plot(out_indices_cpu, debug, DEBUG_HEAD, BLOCK_SIZE_Q):
     for i in numba.prange(out_indices_cpu.shape[1]):
@@ -1294,15 +1306,7 @@ def dual_stage_quadratic_hip_attention(
             - args.block_size_q
         )
 
-    block_sparse_attention_backend = block_sparse_attention
-
-    # Use flashdecode
-    if (
-        (TDST == 1)
-        and (not os.environ.get("HIP_DISABLE_FLASHDECODE", "0") == "1")
-        and (not args.disable_flashdecode)
-    ):
-        block_sparse_attention_backend = decode_block_sparse_attention
+    block_sparse_attention_backend = get_block_sparse_backend(args, q_bsa)
 
     context = block_sparse_attention_backend(
         q=q_bsa,

--- a/src/hip_attn/v1_2/attention_extend.py
+++ b/src/hip_attn/v1_2/attention_extend.py
@@ -123,6 +123,8 @@ def render_plot_ks(indices, ks, debug, DEBUG_HEAD, BLOCK_SIZE_Q):
 
 
 DEBUG = os.getenv("HIP_DEBUG", "0") == "1"
+DEBUG_LOGALL = os.getenv("HIP_DEBUG_LOGALL", '0') == '1'
+__logall_index = 0
 DEBUG_RENDER = os.getenv("HIP_DEBUG_RENDER", "1") == "1"
 
 
@@ -133,8 +135,9 @@ def dual_stage_quadratic_hip_attention(
     args: HiPAttentionArgs,
     cached_metadata: Optional[HiPAttentionOutputMetadata] = None,
 ):
-    DEBUG_HEAD = -1
+    global __logall_index
     global DEBUG
+    DEBUG_HEAD = -1
 
     # if (q.shape[1] == 1) and (not args.disable_flashdecode):
     #     pass
@@ -982,7 +985,12 @@ def dual_stage_quadratic_hip_attention(
                     causal_mask=True,
                     sliding_window_size=args.sliding_window_size,
                 )
-                cv2.imwrite(f"dummy_sampled_stage_{i_stage}.png", debug * 255)
+                if DEBUG_LOGALL:
+                    __logall_index += 1
+                    os.makedirs('./cache/mask_log', exist_ok=True)
+                    cv2.imwrite(f"./cache/mask_log/{__logall_index:04d}_dummy_sampled_stage_{i_stage}.png", debug * 255)
+                else:
+                    cv2.imwrite(f"dummy_sampled_stage_{i_stage}.png", debug * 255)
                 # print(f'saved dummy_sampled_stage_{i_stage}.png')
 
         if STAGE_STRIDE > 1:
@@ -1121,7 +1129,12 @@ def dual_stage_quadratic_hip_attention(
                 (triton.cdiv(TDST, BLOCK_SIZE_Q), triton.cdiv(TSRC, BLOCK_SIZE_Q))
             )
             render_plot(out_indices_cpu, debug, DEBUG_HEAD, BLOCK_SIZE_Q)
-            cv2.imwrite("dummy_sampled_final.png", debug * 255)
+            if DEBUG_LOGALL:
+                os.makedirs('./cache/mask_log', exist_ok=True)
+                __logall_index += 1
+                cv2.imwrite(f"./cache/mask_log/{__logall_index:04d}_dummy_sampled_final.png", debug * 255)
+            else:
+                cv2.imwrite("dummy_sampled_final.png", debug * 255)
             # print('saved dummy_sampled_final.png')
 
         args = args.clone()

--- a/src/hip_attn/v1_2/attention_extend.py
+++ b/src/hip_attn/v1_2/attention_extend.py
@@ -36,6 +36,7 @@ try:
         get_tensor_model_parallel_world_size,
         tensor_model_parallel_all_gather,
     )
+
     SGLANG_DIST_AVAILABLE = True
 except:
     SGLANG_DIST_AVAILABLE = False
@@ -62,8 +63,9 @@ def get_block_sparse_backend(args: HiPAttentionArgs, q: torch.Tensor):
         and (not args.disable_flashdecode)
     ):
         block_sparse_attention_backend = decode_block_sparse_attention
-    
+
     return block_sparse_attention_backend
+
 
 @numba.njit(parallel=True)
 def render_plot(out_indices_cpu, debug, DEBUG_HEAD, BLOCK_SIZE_Q):
@@ -133,7 +135,7 @@ def render_plot_ks(indices, ks, debug, DEBUG_HEAD, BLOCK_SIZE_Q):
 
 
 DEBUG = os.getenv("HIP_DEBUG", "0") == "1"
-DEBUG_LOGALL = os.getenv("HIP_DEBUG_LOGALL", '0') == '1'
+DEBUG_LOGALL = os.getenv("HIP_DEBUG_LOGALL", "0") == "1"
 __logall_index = 0
 DEBUG_RENDER = os.getenv("HIP_DEBUG_RENDER", "1") == "1"
 
@@ -149,11 +151,11 @@ def dual_stage_quadratic_hip_attention(
     global DEBUG
     DEBUG_HEAD = -1
 
-    HIP_DEBUG_LANDMARK_BASED_SCAN_STAGE = os.getenv(
-        'HIP_DEBUG_LANDMARK_BASED_SCAN_STAGE', '0'
-    ) == '1'
+    HIP_DEBUG_LANDMARK_BASED_SCAN_STAGE = (
+        os.getenv("HIP_DEBUG_LANDMARK_BASED_SCAN_STAGE", "0") == "1"
+    )
 
-    if (q.shape[1] == 1):
+    if q.shape[1] == 1:
         pass
     elif HIP_DEBUG_LANDMARK_BASED_SCAN_STAGE:
         # FIXME: just for dev
@@ -499,7 +501,7 @@ def dual_stage_quadratic_hip_attention(
                     k_dense = k[:, :TDST, :, :]
                     chunk_size = 1024
                     for t_start in range(0, TDST, chunk_size):
-                        k_slice = k_dense[:, t_start:t_start+chunk_size]
+                        k_slice = k_dense[:, t_start : t_start + chunk_size]
                 elif (
                     os.getenv("HIP_DEBUG_TOPKMEAN", "0") == "1"
                     and (i_stage == 0)
@@ -833,10 +835,19 @@ def dual_stage_quadratic_hip_attention(
                     # out_scores = out_scores.softmax(dim=2) # NOTE: not good idea
                     # out_scores, _ = torch.max(out_scores, keepdim=True, dim=2)
 
-                    if SGLANG_DIST_AVAILABLE and get_tensor_model_parallel_world_size() > 1:
+                    if (
+                        SGLANG_DIST_AVAILABLE
+                        and get_tensor_model_parallel_world_size() > 1
+                    ):
                         out_scores_tp = out_scores
-                        out_scores = tensor_model_parallel_all_gather(out_scores_tp.permute(0, 1, 3, 2).contiguous()).permute(0, 1, 3, 2).contiguous()
-                    
+                        out_scores = (
+                            tensor_model_parallel_all_gather(
+                                out_scores_tp.permute(0, 1, 3, 2).contiguous()
+                            )
+                            .permute(0, 1, 3, 2)
+                            .contiguous()
+                        )
+
                     out_scores = torch.amax(out_scores, keepdim=True, dim=2)
 
                     out_scores = torch.broadcast_to(out_scores, ori_shape).contiguous()
@@ -1027,8 +1038,11 @@ def dual_stage_quadratic_hip_attention(
                 )
                 if DEBUG_LOGALL:
                     __logall_index += 1
-                    os.makedirs('./cache/mask_log', exist_ok=True)
-                    cv2.imwrite(f"./cache/mask_log/{__logall_index:04d}_dummy_sampled_stage_{i_stage}.png", debug * 255)
+                    os.makedirs("./cache/mask_log", exist_ok=True)
+                    cv2.imwrite(
+                        f"./cache/mask_log/{__logall_index:04d}_dummy_sampled_stage_{i_stage}.png",
+                        debug * 255,
+                    )
                 else:
                     cv2.imwrite(f"dummy_sampled_stage_{i_stage}.png", debug * 255)
                 # print(f'saved dummy_sampled_stage_{i_stage}.png')
@@ -1170,9 +1184,12 @@ def dual_stage_quadratic_hip_attention(
             )
             render_plot(out_indices_cpu, debug, DEBUG_HEAD, BLOCK_SIZE_Q)
             if DEBUG_LOGALL:
-                os.makedirs('./cache/mask_log', exist_ok=True)
+                os.makedirs("./cache/mask_log", exist_ok=True)
                 __logall_index += 1
-                cv2.imwrite(f"./cache/mask_log/{__logall_index:04d}_dummy_sampled_final.png", debug * 255)
+                cv2.imwrite(
+                    f"./cache/mask_log/{__logall_index:04d}_dummy_sampled_final.png",
+                    debug * 255,
+                )
             else:
                 cv2.imwrite("dummy_sampled_final.png", debug * 255)
             # print('saved dummy_sampled_final.png')

--- a/src/hip_attn/v1_2/attention_extend.py
+++ b/src/hip_attn/v1_2/attention_extend.py
@@ -53,6 +53,7 @@ def get_block_sparse_backend(args: HiPAttentionArgs, q: torch.Tensor):
         and (not args.disable_flashdecode)
     ):
         block_sparse_attention_backend = decode_block_sparse_attention
+    
     return block_sparse_attention_backend
 
 @numba.njit(parallel=True)

--- a/src/hip_attn/v1_2/attention_extend.py
+++ b/src/hip_attn/v1_2/attention_extend.py
@@ -31,6 +31,15 @@ from hip_attn.v1_2.compute_v_cos import compute_v_cos
 from hip_attn.v1_2.eval_stage import calculate_chunk_score
 from hip_attn.v1_2.scan_stage import chunk_controllable_sampling_mask_cuda
 
+try:
+    from sglang.srt.distributed import (
+        get_tensor_model_parallel_world_size,
+        tensor_model_parallel_all_gather,
+    )
+    SGLANG_DIST_AVAILABLE = True
+except:
+    SGLANG_DIST_AVAILABLE = False
+
 _NUM_STREAMING_MULTIPROCESSOR = None
 
 
@@ -140,12 +149,24 @@ def dual_stage_quadratic_hip_attention(
     global DEBUG
     DEBUG_HEAD = -1
 
-    # if (q.shape[1] == 1) and (not args.disable_flashdecode):
-    #     pass
-    # else:
-    #     # FIXME: just for dev
-    #     k = args.gather_k_from_paged_cache(chunk_size=args.stages[0].stage_chunk_size)
-    #     v = args.gather_v_from_paged_cache(chunk_size=args.stages[0].stage_chunk_size)
+    HIP_DEBUG_LANDMARK_BASED_SCAN_STAGE = os.getenv(
+        'HIP_DEBUG_LANDMARK_BASED_SCAN_STAGE', '0'
+    ) == '1'
+
+    if (q.shape[1] == 1):
+        pass
+    elif HIP_DEBUG_LANDMARK_BASED_SCAN_STAGE:
+        # FIXME: just for dev
+        k = args.gather_k_from_paged_cache(
+            chunk_size=args.stages[0].stage_chunk_size,
+            disable_gqa=True,
+            gqa_q=q,
+        )
+        # v = args.gather_v_from_paged_cache(
+        #     chunk_size=args.stages[0].stage_chunk_size,
+        #     disable_gqa=True,
+        #     gqa_q=q,
+        # )
 
     if args.q_mask is None:
         q_bsa = q
@@ -471,6 +492,15 @@ def dual_stage_quadratic_hip_attention(
 
                 assert q.shape[1] <= BDST * BLOCK_SIZE_Q
                 if (
+                    HIP_DEBUG_LANDMARK_BASED_SCAN_STAGE
+                    and (BDST > 1)
+                    and (args.position_ids.shape[0] == 1)
+                ):
+                    k_dense = k[:, :TDST, :, :]
+                    chunk_size = 1024
+                    for t_start in range(0, TDST, chunk_size):
+                        k_slice = [:, t_start:t_start+chunk_size]
+                elif (
                     os.getenv("HIP_DEBUG_TOPKMEAN", "0") == "1"
                     and (i_stage == 0)
                     and (BDST > 1)
@@ -801,8 +831,17 @@ def dual_stage_quadratic_hip_attention(
                 if os.getenv("HIP_HEAD_REDUCE", "1") == "1":
                     ori_shape = out_scores.shape
                     # out_scores = out_scores.softmax(dim=2) # NOTE: not good idea
-                    out_scores, _ = torch.max(out_scores, keepdim=True, dim=2)
+                    # out_scores, _ = torch.max(out_scores, keepdim=True, dim=2)
+
+                    if SGLANG_DIST_AVAILABLE and get_tensor_model_parallel_world_size() > 1:
+                        out_scores_tp = out_scores
+                        out_scores = tensor_model_parallel_all_gather(out_scores_tp.permute(0, 1, 3, 2).contiguous()).permute(0, 1, 3, 2).contiguous()
+                    
+                    out_scores = torch.amax(out_scores, keepdim=True, dim=2)
+
                     out_scores = torch.broadcast_to(out_scores, ori_shape).contiguous()
+                else:
+                    args.disable_flashdecode = True
 
                 if args.offload_cache is not None:
                     # print('after masking')

--- a/src/hip_attn/v1_2/attention_extend_bsa.py
+++ b/src/hip_attn/v1_2/attention_extend_bsa.py
@@ -50,6 +50,7 @@ def apply_rope_to_keys(
     EXCLUDE_SLIDING_WINDOW: tl.constexpr,
     NEED_APPLY_ROPE: tl.constexpr,
     EXTEND_BACKEND: tl.constexpr,
+    CHUNKED_SW: tl.constexpr = False,
 ):
     if EXTEND_BACKEND == "self_extend":
         raise Exception()
@@ -471,6 +472,7 @@ def block_sparse_attention_cuda_step(
         qk = tl.extra.cuda.libdevice.tanh(qk / LOGIT_SOFTCAP) * LOGIT_SOFTCAP
     qk = qk * 1.44269504
 
+    # if qk_mask == True, then dropped
     if IS_CAUSAL:
         if EXCLUDE_SLIDING_WINDOW:
             qk_mask = (
@@ -479,11 +481,28 @@ def block_sparse_attention_cuda_step(
                 | (~(mask_tdst[:, None] & mask_tsrc[None, :]))
             )
         else:
-            qk_mask = (
-                ((pos_tdst - 1)[:, None] < idx_tsrc[None, :])
-                | ((pos_tdst - 1)[:, None] >= (idx_tsrc + sliding_window_size)[None, :])
-                | (~(mask_tdst[:, None] & mask_tsrc[None, :]))
-            )
+            if not CHUNKED_SW:
+                qk_mask = (
+                    ((pos_tdst - 1)[:, None] < idx_tsrc[None, :])
+                    | ((pos_tdst - 1)[:, None] >= (idx_tsrc + sliding_window_size)[None, :])
+                    | (~(mask_tdst[:, None] & mask_tsrc[None, :]))
+                )
+            else:
+                # qk_mask = (
+                #     ((pos_tdst - 1)[:, None] < idx_tsrc[None, :])
+                #     | ((pos_tdst - 1)[:, None] >= (idx_tsrc + sliding_window_size)[None, :])
+                #     | (~(mask_tdst[:, None] & mask_tsrc[None, :]))
+                # )
+                qk_mask = (
+                    ((pos_tdst - 1)[:, None] < idx_tsrc[None, :])
+                    # | ((pos_tdst - 1)[:, None] >= (idx_tsrc + sliding_window_size)[None, :])
+                    | (~(mask_tdst[:, None] & mask_tsrc[None, :]))
+                    # | idx_tsrc[None, :] < ((pos_tdst - 1) - ((pos_tdst - 1) % sliding_window_size))[:, None]
+                    | (
+                        (idx_tsrc[None, :] < ((pos_tdst - 1) // sliding_window_size * sliding_window_size)[:, None])
+                        & ((pos_tdst - 1)[:, None] >= (idx_tsrc + 1)[None, :])
+                    )
+                )
     else:
         qk_mask = ~(mask_tdst[:, None] & mask_tsrc[None, :])
 
@@ -783,6 +802,7 @@ def block_sparse_attention_cuda(
     BLOCK_BK: tl.constexpr,
     EXTEND_BACKEND: tl.constexpr,
     UPDATE_CACHE: tl.constexpr,
+    CHUNKED_SW: tl.constexpr,
 ):
     G: tl.constexpr = 1
 
@@ -1765,7 +1785,7 @@ def block_sparse_attention_cuda(
                 EXTEND_BACKEND=EXTEND_BACKEND,
             )
 
-    if sliding_window_size > 0:
+    if (sliding_window_size > 0) and True:
         CURR_TSRC = tl.max(pos_tdst)
         # CURR_TSRC = (idx_bdst + 1) * BLOCK_SIZE_Q + MAX_TSRC - MAX_TDST
         i_tsrc_range_start = tl.maximum(
@@ -2165,6 +2185,7 @@ def block_sparse_attention_cuda(
                 BLOCK_BK * BLOCK_SIZE_K,
                 BLOCK_SIZE_K,
                 EXTEND_BACKEND=EXTEND_BACKEND,
+                CHUNKED_SW=CHUNKED_SW,
             )
 
     # epilogue
@@ -2362,6 +2383,7 @@ def block_sparse_attention(
         BLOCK_BK=BLOCK_BK,
         EXTEND_BACKEND=EXTEND_BACKEND,
         UPDATE_CACHE=offload_update_cache,
+        CHUNKED_SW=args.using_chunked_sliding_window,
         # num_warps=4,
         # num_stages=2 if not using_extend else 1,
     )

--- a/src/hip_attn/v1_2/attention_extend_bsa.py
+++ b/src/hip_attn/v1_2/attention_extend_bsa.py
@@ -485,7 +485,10 @@ def block_sparse_attention_cuda_step(
             if not CHUNKED_SW:
                 qk_mask = (
                     ((pos_tdst - 1)[:, None] < idx_tsrc[None, :])
-                    | ((pos_tdst - 1)[:, None] >= (idx_tsrc + sliding_window_size)[None, :])
+                    | (
+                        (pos_tdst - 1)[:, None]
+                        >= (idx_tsrc + sliding_window_size)[None, :]
+                    )
                     | (~(mask_tdst[:, None] & mask_tsrc[None, :]))
                 )
             else:
@@ -500,7 +503,14 @@ def block_sparse_attention_cuda_step(
                     | (~(mask_tdst[:, None] & mask_tsrc[None, :]))
                     # | idx_tsrc[None, :] < ((pos_tdst - 1) - ((pos_tdst - 1) % sliding_window_size))[:, None]
                     | (
-                        (idx_tsrc[None, :] < ((pos_tdst - 1) // sliding_window_size * sliding_window_size)[:, None])
+                        (
+                            idx_tsrc[None, :]
+                            < (
+                                (pos_tdst - 1)
+                                // sliding_window_size
+                                * sliding_window_size
+                            )[:, None]
+                        )
                         & ((pos_tdst - 1)[:, None] >= (idx_tsrc + 1)[None, :])
                     )
                 )

--- a/src/hip_attn/v1_2/attention_extend_bsa.py
+++ b/src/hip_attn/v1_2/attention_extend_bsa.py
@@ -50,7 +50,6 @@ def apply_rope_to_keys(
     EXCLUDE_SLIDING_WINDOW: tl.constexpr,
     NEED_APPLY_ROPE: tl.constexpr,
     EXTEND_BACKEND: tl.constexpr,
-    CHUNKED_SW: tl.constexpr = False,
 ):
     if EXTEND_BACKEND == "self_extend":
         raise Exception()
@@ -373,6 +372,7 @@ def block_sparse_attention_cuda_step(
     BLOCK_TK,
     BLOCK_SIZE_K: tl.constexpr,
     EXTEND_BACKEND: tl.constexpr = DEFAULT_EXTEND_BACKEND,
+    CHUNKED_SW: tl.constexpr = False,
 ):
     HID_BLOCK_0: tl.constexpr = queries_0.shape[1]
     HID_BLOCK_1: tl.constexpr = queries_1.shape[1] if queries_1 is not None else 0

--- a/src/hip_attn/v1_2/attention_extend_bsa.py
+++ b/src/hip_attn/v1_2/attention_extend_bsa.py
@@ -481,6 +481,7 @@ def block_sparse_attention_cuda_step(
                 | (~(mask_tdst[:, None] & mask_tsrc[None, :]))
             )
         else:
+            # TODO(ainl): we should reduce scanning loop range if CHUNKED_SW is true.
             if not CHUNKED_SW:
                 qk_mask = (
                     ((pos_tdst - 1)[:, None] < idx_tsrc[None, :])

--- a/src/hip_attn/v1_2/attention_extend_bsa.py
+++ b/src/hip_attn/v1_2/attention_extend_bsa.py
@@ -491,7 +491,7 @@ def block_sparse_attention_cuda_step(
             else:
                 # qk_mask = (
                 #     ((pos_tdst - 1)[:, None] < idx_tsrc[None, :])
-                #     | ((pos_tdst - 1)[:, None] >= (idx_tsrc + sliding_window_size)[None, :])
+                #     | ((pos_tdst - 1)[:, None] >= (idx_tsrc + 1024)[None, :])
                 #     | (~(mask_tdst[:, None] & mask_tsrc[None, :]))
                 # )
                 qk_mask = (

--- a/src/hip_attn/v1_2/attention_metadata.py
+++ b/src/hip_attn/v1_2/attention_metadata.py
@@ -214,6 +214,8 @@ class HiPAttentionArgs:
 
     sliding_window_indices: Optional[torch.Tensor] = None
 
+    using_chunked_sliding_window: bool = False
+
     # NOTE: use only for debugging purpose
     layer_id: int = 31
 

--- a/src/hip_attn/v1_2/model_offload_cache.py
+++ b/src/hip_attn/v1_2/model_offload_cache.py
@@ -69,9 +69,8 @@ class HiPModelOffloadCache:
                     cur_max_mask_cache_token_size *= 2
             else:
                 base_mask_cache_tokens = (
-                    layer_config.sink_token_size
-                    + layer_config.sliding_window_size
-                    + layer_config.second_stage_k
+                    (max_token_size / layer_config.stages[0].stage_chunk_size)
+                    * 2 * math.log2(layer_config.stages[0].stage_chunk_size)
                 )
                 cur_max_mask_cache_token_size = math.ceil(
                     max_mask_cache_factor * base_mask_cache_tokens
@@ -83,7 +82,9 @@ class HiPModelOffloadCache:
                     cur_max_sa_cache_token_size *= 2
             else:
                 base_sa_cache_tokens = (
-                    max_token_size / layer_config.stages[0].stage_chunk_size
+                    layer_config.sink_token_size
+                    + layer_config.sliding_window_size
+                    + layer_config.second_stage_k
                 )
                 cur_max_sa_cache_token_size = math.ceil(
                     max_sa_cache_factor * base_sa_cache_tokens

--- a/src/hip_attn/v1_2/model_offload_cache.py
+++ b/src/hip_attn/v1_2/model_offload_cache.py
@@ -70,7 +70,8 @@ class HiPModelOffloadCache:
             else:
                 base_mask_cache_tokens = (
                     (max_token_size / layer_config.stages[0].stage_chunk_size)
-                    * 2 * math.log2(layer_config.stages[0].stage_chunk_size)
+                    * 2
+                    * math.log2(layer_config.stages[0].stage_chunk_size)
                 )
                 cur_max_mask_cache_token_size = math.ceil(
                     max_mask_cache_factor * base_mask_cache_tokens

--- a/src/hip_attn/v1_2/paged_hip.py
+++ b/src/hip_attn/v1_2/paged_hip.py
@@ -5,8 +5,10 @@ from typing import Any, Optional
 import torch
 import triton
 
-from hip_attn.v1_2.attention_extend import dual_stage_quadratic_hip_attention
-from hip_attn.v1_2.attention_extend import get_block_sparse_backend
+from hip_attn.v1_2.attention_extend import (
+    dual_stage_quadratic_hip_attention,
+    get_block_sparse_backend,
+)
 from hip_attn.v1_2.attention_metadata import (
     HiPAttentionArgs,
     HiPAttentionOutputMetadata,
@@ -694,7 +696,7 @@ def _forward_paged_hip(
         bsa_fn = get_block_sparse_backend(args, query)
 
         # dist.barrier()
-        # if get_tensor_model_parallel_rank() == 0: 
+        # if get_tensor_model_parallel_rank() == 0:
         #     print(bsa_fn, args.using_extend, sliding_window_size, args.using_chunked_sliding_window)
 
         BSZ, TDST, HEAD, HID = query.shape
@@ -706,7 +708,9 @@ def _forward_paged_hip(
         args.block_size_k = args.stages[-1].stage_chunk_size
         args.second_stage_k = 0
         args.sink_token_size = 0
-        args.sliding_window_size = sliding_window_size if sliding_window_size is not None else 1024
+        args.sliding_window_size = (
+            sliding_window_size if sliding_window_size is not None else 1024
+        )
         args.sliding_window_indices = None
 
         BDST = triton.cdiv(TDST, args.block_size_q)

--- a/src/hip_attn/v1_2/paged_hip.py
+++ b/src/hip_attn/v1_2/paged_hip.py
@@ -15,6 +15,7 @@ from hip_attn.v1_2.hip_config import HiPAttentionConfig
 from hip_attn.v1_2.uvm_gpu_cache import HiPOffloadCache
 
 try:
+    import torch.distributed as dist
     from sglang.srt.distributed import (
         get_tensor_model_parallel_rank,
         split_tensor_along_last_dim,
@@ -68,6 +69,7 @@ def forward_paged_hip(
     query_for_mask: Optional[torch.Tensor] = None,
     diag_sliding_window_indices: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = -1,
+    using_chunked_sliding_window: bool = False,
 ) -> tuple[torch.Tensor, HiPAttentionOutputMetadata]:
 
     if is_prefill is not None:
@@ -173,6 +175,7 @@ def forward_paged_hip(
                     query_for_mask=query_for_mask,
                     diag_sliding_window_indices=diag_sliding_window_indices,
                     sliding_window_size=sliding_window_size,
+                    using_chunked_sliding_window=using_chunked_sliding_window,
                 )
 
                 o[start_len : start_len + seq_len] = o_req
@@ -213,6 +216,7 @@ def forward_paged_hip(
             query_for_mask=query_for_mask,
             diag_sliding_window_indices=diag_sliding_window_indices,
             sliding_window_size=sliding_window_size,
+            using_chunked_sliding_window=using_chunked_sliding_window,
         )
 
     return o, metadata_new
@@ -249,6 +253,7 @@ def _forward_paged_hip_validate(
     query_for_mask: Optional[torch.Tensor] = None,
     diag_sliding_window_indices: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = -1,
+    using_chunked_sliding_window: bool = False,
 ) -> tuple[torch.Tensor, HiPAttentionOutputMetadata]:
 
     if is_kv_cache_offload_enabled:
@@ -322,6 +327,7 @@ def _forward_paged_hip_validate(
         query_for_mask=query_for_mask,
         diag_sliding_window_indices=diag_sliding_window_indices,
         sliding_window_size=sliding_window_size,
+        using_chunked_sliding_window=using_chunked_sliding_window,
     )
 
     if require_validation:
@@ -355,6 +361,7 @@ def _forward_paged_hip_validate(
                 query_for_mask=query_for_mask,
                 diag_sliding_window_indices=diag_sliding_window_indices,
                 sliding_window_size=sliding_window_size,
+                using_chunked_sliding_window=using_chunked_sliding_window,
             )
 
             o_err = ((o - o_req_valid) ** 2).sum()
@@ -390,6 +397,7 @@ def _forward_paged_hip_validate(
                 query_for_mask=query_for_mask,
                 diag_sliding_window_indices=diag_sliding_window_indices,
                 sliding_window_size=sliding_window_size,
+                using_chunked_sliding_window=using_chunked_sliding_window,
             )
 
             err_thresh = 1e-7
@@ -465,6 +473,7 @@ def _forward_paged_hip_validate(
                     query_for_mask=query_for_mask,
                     diag_sliding_window_indices=diag_sliding_window_indices,
                     sliding_window_size=sliding_window_size,
+                    using_chunked_sliding_window=using_chunked_sliding_window,
                 )
 
                 offload_cache.sa_kv_cache.flush()
@@ -499,6 +508,7 @@ def _forward_paged_hip_validate(
                     query_for_mask=query_for_mask,
                     diag_sliding_window_indices=diag_sliding_window_indices,
                     sliding_window_size=sliding_window_size,
+                    using_chunked_sliding_window=using_chunked_sliding_window,
                 )
                 err_uvm = sse(o, o_uvm)
                 err_retry = sse(o_valid, o_retry)
@@ -564,6 +574,7 @@ def _forward_paged_hip(
     query_for_mask: Optional[torch.Tensor] = None,
     diag_sliding_window_indices: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = -1,
+    using_chunked_sliding_window: bool = False,
 ) -> tuple[torch.Tensor, HiPAttentionOutputMetadata]:
     global _CHECKOUT_COUNTER
 
@@ -674,6 +685,7 @@ def _forward_paged_hip(
         ),
         layer_id=layer_id,
         v_hidden_dim=v_hidden_dim,
+        using_chunked_sliding_window=using_chunked_sliding_window,
     )
 
     last_dense = int(os.getenv("HIP_DEBUG_LAST_DENSE", "64"))

--- a/src/hip_attn/v1_2/paged_hip.py
+++ b/src/hip_attn/v1_2/paged_hip.py
@@ -79,9 +79,9 @@ def forward_paged_hip(
         is_decode = not is_prefill
 
     if v is None:
-        warnings.warn(
-            "Deprecated behavior: `k` and `v` should be provided in order to precisely know the output size."
-        )
+        # warnings.warn(
+        #     "Deprecated behavior: `k` and `v` should be provided in order to precisely know the output size."
+        # )
 
         if v_cache is not None:
             v_hidden_dim = v_cache.shape[-1]
@@ -692,8 +692,16 @@ def _forward_paged_hip(
 
     if isinstance(sliding_window_size, int) and (sliding_window_size > 0):
         bsa_fn = get_block_sparse_backend(args, query)
-        
+
+        # dist.barrier()
+        # if get_tensor_model_parallel_rank() == 0: 
+        #     print(bsa_fn, args.using_extend, sliding_window_size, args.using_chunked_sliding_window)
+
+        BSZ, TDST, HEAD, HID = query.shape
+
         args = args.clone()
+        if args.rope_range is None:
+            args.rope_range = (0, HID)
         args.block_size_q = args.block_sparse_block_size_q
         args.block_size_k = args.stages[-1].stage_chunk_size
         args.second_stage_k = 0
@@ -701,7 +709,6 @@ def _forward_paged_hip(
         args.sliding_window_size = sliding_window_size if sliding_window_size is not None else 1024
         args.sliding_window_indices = None
 
-        BSZ, TDST, HEAD, HID = query.shape
         BDST = triton.cdiv(TDST, args.block_size_q)
         BH = BSZ * HEAD
 
@@ -732,6 +739,9 @@ def _forward_paged_hip(
         context = context.to(query.dtype)
         metadata = None
     elif is_decode or (query.shape[1] < (last_dense * 2)):
+        # dist.barrier()
+        # if get_tensor_model_parallel_rank() == 0: print('hip')
+
         context, metadata = dual_stage_quadratic_hip_attention(
             (query * sm_scale).to(query.dtype),
             k,

--- a/src/hip_attn/v1_2/paged_hip.py
+++ b/src/hip_attn/v1_2/paged_hip.py
@@ -3,8 +3,10 @@ import warnings
 from typing import Any, Optional
 
 import torch
+import triton
 
 from hip_attn.v1_2.attention_extend import dual_stage_quadratic_hip_attention
+from hip_attn.v1_2.attention_extend import get_block_sparse_backend
 from hip_attn.v1_2.attention_metadata import (
     HiPAttentionArgs,
     HiPAttentionOutputMetadata,
@@ -65,6 +67,7 @@ def forward_paged_hip(
     is_decode: bool = False,
     query_for_mask: Optional[torch.Tensor] = None,
     diag_sliding_window_indices: Optional[torch.Tensor] = None,
+    sliding_window_size: Optional[int] = -1,
 ) -> tuple[torch.Tensor, HiPAttentionOutputMetadata]:
 
     if is_prefill is not None:
@@ -169,6 +172,7 @@ def forward_paged_hip(
                     is_decode=is_decode,
                     query_for_mask=query_for_mask,
                     diag_sliding_window_indices=diag_sliding_window_indices,
+                    sliding_window_size=sliding_window_size,
                 )
 
                 o[start_len : start_len + seq_len] = o_req
@@ -208,6 +212,7 @@ def forward_paged_hip(
             is_decode=is_decode,
             query_for_mask=query_for_mask,
             diag_sliding_window_indices=diag_sliding_window_indices,
+            sliding_window_size=sliding_window_size,
         )
 
     return o, metadata_new
@@ -243,6 +248,7 @@ def _forward_paged_hip_validate(
     is_decode: bool = False,
     query_for_mask: Optional[torch.Tensor] = None,
     diag_sliding_window_indices: Optional[torch.Tensor] = None,
+    sliding_window_size: Optional[int] = -1,
 ) -> tuple[torch.Tensor, HiPAttentionOutputMetadata]:
 
     if is_kv_cache_offload_enabled:
@@ -315,6 +321,7 @@ def _forward_paged_hip_validate(
         is_decode=is_decode,
         query_for_mask=query_for_mask,
         diag_sliding_window_indices=diag_sliding_window_indices,
+        sliding_window_size=sliding_window_size,
     )
 
     if require_validation:
@@ -347,6 +354,7 @@ def _forward_paged_hip_validate(
                 is_decode=is_decode,
                 query_for_mask=query_for_mask,
                 diag_sliding_window_indices=diag_sliding_window_indices,
+                sliding_window_size=sliding_window_size,
             )
 
             o_err = ((o - o_req_valid) ** 2).sum()
@@ -381,6 +389,7 @@ def _forward_paged_hip_validate(
                 is_decode=is_decode,
                 query_for_mask=query_for_mask,
                 diag_sliding_window_indices=diag_sliding_window_indices,
+                sliding_window_size=sliding_window_size,
             )
 
             err_thresh = 1e-7
@@ -455,6 +464,7 @@ def _forward_paged_hip_validate(
                     is_decode=is_decode,
                     query_for_mask=query_for_mask,
                     diag_sliding_window_indices=diag_sliding_window_indices,
+                    sliding_window_size=sliding_window_size,
                 )
 
                 offload_cache.sa_kv_cache.flush()
@@ -488,6 +498,7 @@ def _forward_paged_hip_validate(
                     is_decode=is_decode,
                     query_for_mask=query_for_mask,
                     diag_sliding_window_indices=diag_sliding_window_indices,
+                    sliding_window_size=sliding_window_size,
                 )
                 err_uvm = sse(o, o_uvm)
                 err_retry = sse(o_valid, o_retry)
@@ -552,6 +563,7 @@ def _forward_paged_hip(
     is_decode: bool = False,
     query_for_mask: Optional[torch.Tensor] = None,
     diag_sliding_window_indices: Optional[torch.Tensor] = None,
+    sliding_window_size: Optional[int] = -1,
 ) -> tuple[torch.Tensor, HiPAttentionOutputMetadata]:
     global _CHECKOUT_COUNTER
 
@@ -666,7 +678,48 @@ def _forward_paged_hip(
 
     last_dense = int(os.getenv("HIP_DEBUG_LAST_DENSE", "64"))
 
-    if is_decode or (query.shape[1] < (last_dense * 2)):
+    if isinstance(sliding_window_size, int) and (sliding_window_size > 0):
+        bsa_fn = get_block_sparse_backend(args, query)
+        
+        args = args.clone()
+        args.block_size_q = args.block_sparse_block_size_q
+        args.block_size_k = args.stages[-1].stage_chunk_size
+        args.second_stage_k = 0
+        args.sink_token_size = 0
+        args.sliding_window_size = sliding_window_size if sliding_window_size is not None else 1024
+        args.sliding_window_indices = None
+
+        BSZ, TDST, HEAD, HID = query.shape
+        BDST = triton.cdiv(TDST, args.block_size_q)
+        BH = BSZ * HEAD
+
+        indices = torch.zeros((BH, BDST, 0), dtype=torch.int64, device=query.device)
+        ks = torch.zeros((BH, BDST), dtype=torch.int64, device=query.device)
+        ks_count = ks.unsqueeze(-1)
+        ks_start_end = torch.zeros(
+            (BH, BDST, 2), dtype=torch.int64, device=query.device
+        )
+
+        context = bsa_fn(
+            q=(query * sm_scale).to(query.dtype),
+            k=k,
+            v=v,
+            seq_lens=args.position_ids + 1,
+            indices=indices,
+            ks=ks,
+            ks_count=ks_count,
+            ks_start_end=ks_start_end,
+            access_counter=None,
+            cache_miss_counter=None,
+            EXTEND_BACKEND=args.sa_extend_backend,
+            model_context_length=args.model_context_length,
+            extend_context_length=args.extend_context_length,
+            offload_update_cache=False,
+            args=args,
+        )
+        context = context.to(query.dtype)
+        metadata = None
+    elif is_decode or (query.shape[1] < (last_dense * 2)):
         context, metadata = dual_stage_quadratic_hip_attention(
             (query * sm_scale).to(query.dtype),
             k,


### PR DESCRIPTION
Tested command:

```
HIP_DEBUG_LAST_DENSE=64 \
SA_BLOCK_SIZE=64 \
HIP_HEAD_REDUCE=0 \
HIP_DISABLE_FLASHDECODE=1 \
python3 -m sglang.launch_server \
--model-path meta-llama/Llama-4-Scout-17B-16E-Instruct --tp 8 \
--context-length 1048576 --enable-hip-attention \
--hip-attention-config '{"using_extend": false}' \
--max-running-request 32 --cuda-graph-bs 1 2 4 8 16 24 32 \
--chunked-prefill-size 131072
```

Performance (Llama 4 Scout, InfiniteBench En.QA, InfLLM Prompt):


Attention | Metric | 128K | 256K | 384K
-- | -- | -- | -- | --
FA3 | QA F1 | 0.371 | 0.400 | 0.391
FA3  | QA Rec | 0.445 | 0.476 | 0.476
HiP | QA F1 | 0.387 | 0.429 | 0.434
HiP  | QA Rec | 0.446 | 0.475 | 0.482