### PR TITLE
feat: bump to 1.2.5 and update doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ third_party/
 dummy*.png
 dummy*.jpg
 flux-dev.png
+
+.env

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ See the following pages for more details:
 ```bash
 git clone git@github.com:DeepAuto-AI/hip-attention.git
 cd hip-attention
-docker build -t hip-sglang:latest -t hip-sglang:$(git rev-parse --short HEAD) -f Dockerfile.sglang .
+docker build -t hip-attention:latest -t hip-attention:latest-sglang -t hip-attention:$(git rev-parse --short HEAD)-sglang -t hip-attention:v$(uv run python -c 'import importlib.metadata; print(importlib.metadata.version("hip-attn"))')-sglang -f Dockerfile.sglang .
 ```
 
 ## Experiment Reproduce
@@ -157,8 +157,21 @@ Check [how to reproduce experiment](docs/REPRODUCE.md) page
 
 ### Building and publishing
 
+- PyPI
+
 ```bash
 rm -rf dist
 uv build --no-sources
 uv publish
+```
+
+- Docker
+
+```bash
+docker login
+docker build -t deepauto/hip-attention:latest -t deepauto/hip-attention:latest-sglang -t deepauto/hip-attention:$(git rev-parse --short HEAD)-sglang -t deepauto/hip-attention:v$(uv run python -c 'import importlib.metadata; print(importlib.metadata.version("hip-attn"))')-sglang -f Dockerfile.sglang .
+docker push deepauto/hip-attention:latest
+docker push deepauto/hip-attention:latest-sglang
+docker push deepauto/hip-attention:$(git rev-parse --short HEAD)-sglang
+docker push deepauto/hip-attention:v$(uv run python -c 'import importlib.metadata; print(importlib.metadata.version("hip-attn"))')-sglang
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@
 
 ## Usage
 
+[`hip-attn` package is available on PyPI](https://pypi.org/project/hip-attn/):
+
+```bash
+pip install hip-attn
+```
+
+or using uv:
+
+```bash
+uv add hip-attn
+```
+
 After installation, you can access the `hip` package from any project. `hip` is the code name of HiP attention.
 
 ```py
@@ -112,20 +124,16 @@ pip install -e ".[sglang]" \
 --find-links https://flashinfer.ai/whl/cu124/torch2.5/flashinfer-python
 ```
 
+### Docker
+
+Docker images `deepauto/hip-attention` are available on [Docker Hub](https://hub.docker.com/r/deepauto/hip-attention).
+Docker examples are available in [Running section](#running).
+
 ### Running
 
 See the following pages for more details:
 
 - [Running OpenAI API server examples (SGlang)](docs/USAGE.sglang.md)
-
-
-### Building Docker
-
-```bash
-git clone git@github.com:DeepAuto-AI/hip-attention.git
-cd hip-attention
-docker build -t hip-attention:latest -t hip-attention:latest-sglang -t hip-attention:$(git rev-parse --short HEAD)-sglang -t hip-attention:v$(uv run python -c 'import importlib.metadata; print(importlib.metadata.version("hip-attn"))')-sglang -f Dockerfile.sglang .
-```
 
 ## Experiment Reproduce
 
@@ -168,8 +176,12 @@ uv publish
 - Docker
 
 ```bash
+git clone git@github.com:DeepAuto-AI/hip-attention.git
+cd hip-attention
 docker login
+
 docker build -t deepauto/hip-attention:latest -t deepauto/hip-attention:latest-sglang -t deepauto/hip-attention:$(git rev-parse --short HEAD)-sglang -t deepauto/hip-attention:v$(uv run python -c 'import importlib.metadata; print(importlib.metadata.version("hip-attn"))')-sglang -f Dockerfile.sglang .
+
 docker push deepauto/hip-attention:latest
 docker push deepauto/hip-attention:latest-sglang
 docker push deepauto/hip-attention:$(git rev-parse --short HEAD)-sglang

--- a/docs/USAGE.sglang.md
+++ b/docs/USAGE.sglang.md
@@ -1,6 +1,7 @@
 # Running HiP Attention with SGLang OpenAI server
 
 - [Running HiP Attention with SGLang OpenAI server](#running-hip-attention-with-sglang-openai-server)
+  - [Prerequisites](#prerequisites)
   - [Testing](#testing)
   - [`meta-llama/Llama-3.1-8B-Instruct`](#meta-llamallama-31-8b-instruct)
     - [Single GPU (with cache offloading)](#single-gpu-with-cache-offloading)
@@ -29,13 +30,36 @@
     - [Multi GPU (with cache offloading)](#multi-gpu-with-cache-offloading-4)
       - [Local](#local-7)
       - [Docker](#docker-5)
+  - [`meta-llama/Llama-4-Scout-17B-16E-Instruct`](#meta-llamallama-4-scout-17b-16e-instruct)
+    - [1M Context (without cache offloading)](#1m-context-without-cache-offloading)
+      - [Local](#local-8)
+      - [Docker](#docker-6)
+  - [`meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8`](#meta-llamallama-4-maverick-17b-128e-instruct-fp8)
+    - [1M -\> 2M Context (with cache offloading)](#1m---2m-context-with-cache-offloading)
+      - [Local](#local-9)
+      - [Docker](#docker-7)
+  - [`Qwen/Qwen3-30B-A3B`](#qwenqwen3-30b-a3b)
+    - [32K -\> 2M Context (without cache offloading)](#32k---2m-context-without-cache-offloading)
+      - [Local](#local-10)
+      - [Docker](#docker-8)
+    - [32K -\> 5M Context (with cache offloading)](#32k---5m-context-with-cache-offloading)
+      - [Local](#local-11)
+      - [Docker](#docker-9)
+
+## Prerequisites
+
+- Export the `HF_TOKEN` environment variable.
+
+```bash
+export HF_TOKEN=<secret>
+```
 
 ## Testing
 
 ```bash
-SRT_PORT=8921 uv run scripts/test_openai.py
+SRT_PORT=30000 uv run scripts/test_openai.py
 # 1M tokens
-SRT_PORT=8921 uv run scripts/test_openai_long.py
+SRT_PORT=30000 uv run scripts/test_openai_long.py
 ```
 
 ## `meta-llama/Llama-3.1-8B-Instruct`
@@ -359,7 +383,7 @@ docker run --rm --runtime nvidia \
 -p $SRT_PORT:$SRT_PORT \
 --ipc=host \
 -v ~/.cache/huggingface:/root/.cache/huggingface \
---env "HF_TOKEN=<secret>" \
+--env "HF_TOKEN=${HF_TOKEN}" \
 --env "HIP_DEBUG_UNION_HEAD=$HIP_DEBUG_UNION_HEAD" \
 --env "HIP_HEAD_REDUCE=$HIP_HEAD_REDUCE" \
 --env "SRT_WARMUP_PASSKEY_LENGTH=$SRT_WARMUP_PASSKEY_LENGTH" \
@@ -456,7 +480,7 @@ docker run --rm --runtime nvidia \
 -p $SRT_PORT:$SRT_PORT \
 --ipc=host \
 -v ~/.cache/huggingface:/root/.cache/huggingface \
---env "HF_TOKEN=<secret>" \
+--env "HF_TOKEN=${HF_TOKEN}" \
 --env "HIP_DEBUG_UNION_HEAD=$HIP_DEBUG_UNION_HEAD" \
 --env "HIP_HEAD_REDUCE=$HIP_HEAD_REDUCE" \
 --env "SRT_WARMUP_PASSKEY_LENGTH=$SRT_WARMUP_PASSKEY_LENGTH" \
@@ -547,7 +571,7 @@ docker run --rm --runtime nvidia \
 -p $SRT_PORT:$SRT_PORT \
 --ipc=host \
 -v ~/.cache/huggingface:/root/.cache/huggingface \
---env "HF_TOKEN=<secret>" \
+--env "HF_TOKEN=${HF_TOKEN}" \
 --env "SRT_WARMUP_PASSKEY_LENGTH=$SRT_WARMUP_PASSKEY_LENGTH" \
 hip-sglang:latest \
 python \
@@ -631,7 +655,7 @@ docker run --rm --runtime nvidia \
 -p $SRT_PORT:$SRT_PORT \
 --ipc=host \
 -v ~/.cache/huggingface:/root/.cache/huggingface \
---env "HF_TOKEN=<secret>" \
+--env "HF_TOKEN=${HF_TOKEN}" \
 --env "SRT_WARMUP_PASSKEY_LENGTH=$SRT_WARMUP_PASSKEY_LENGTH" \
 hip-sglang:latest \
 python \
@@ -653,4 +677,293 @@ python \
 --enable-hip-offload \
 --hip-max-sa-cache-token-size 3000 \
 --hip-max-mask-cache-token-size 32000
+```
+
+## `meta-llama/Llama-4-Scout-17B-16E-Instruct`
+
+### 1M Context (without cache offloading)
+
+- 1M context length
+- Cache offloading disabled
+- Tested model: `meta-llama/Llama-4-Scout-17B-16E-Instruct`
+- Testwd GPU: 8x H100 80GB
+- Tested at: 2025-05-19
+- Tested version:
+  - `hip-attention`: `3974c558f79149584847576ad27a7adf32d30be5`
+  - `sglang` ([DeepAuto-AI/sglang](https://github.com/DeepAuto-AI/sglang)): `8125e3e029a9f90c7800199d1a9939ffda5fa871`
+
+#### Local
+
+```bash
+HIP_CONFIG_PRESET=llama4 \
+HIP_DISABLE_FLASHDECODE=0 \
+HIP_HEAD_REDUCE=0 \
+HIP_DEBUG_FORCE_DENSE_DECODE=1 \
+uv run \
+--env-file ".env" \
+-m sglang.launch_server \
+--model-path meta-llama/Llama-4-Scout-17B-16E-Instruct \
+--served-model-name deepauto/llama-4-scout-1m-ctx \
+--host 0.0.0.0 \
+--port 30000 \
+--tp 8 \
+--max-total-tokens 1000000 \
+--context-length 1000000 \
+--cuda-graph-bs 1 2 4 8 16 24 32 \
+--max-running-req 32 \
+--chunked-prefill-size 65536 \
+--enable-hip-attention \
+--hip-attention-config '{"using_extend": false, "dense_layers": [0, 1, 2, 3]}' \
+--attention-backend flashinfer \
+--chat-template llama-4
+```
+
+#### Docker
+
+```bash
+docker run --rm \
+--gpus all \
+--name deepauto-llama-4-scout-1m-ctx \
+-p 30000:30000 \
+--ipc=host \
+-v ~/.cache/huggingface:/root/.cache/huggingface \
+--env "HF_TOKEN=${HF_TOKEN}" \
+--env "HIP_CONFIG_PRESET=llama4" \
+--env "HIP_DISABLE_FLASHDECODE=0" \
+--env "HIP_HEAD_REDUCE=0" \
+--env "HIP_DEBUG_FORCE_DENSE_DECODE=1" \
+deepauto/hip-attention:v1.2.5-sglang \
+python \
+-m sglang.launch_server \
+--model-path meta-llama/Llama-4-Scout-17B-16E-Instruct \
+--served-model-name deepauto/llama-4-scout-1m-ctx \
+--host 0.0.0.0 \
+--port 30000 \
+--tp 8 \
+--max-total-tokens 1000000 \
+--context-length 1000000 \
+--cuda-graph-bs 1 2 4 8 16 24 32 \
+--max-running-req 32 \
+--chunked-prefill-size 65536 \
+--enable-hip-attention \
+--hip-attention-config '{"using_extend": false, "dense_layers": [0, 1, 2, 3]}' \
+--attention-backend flashinfer \
+--chat-template llama-4
+```
+
+## `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8`
+
+### 1M -\> 2M Context (with cache offloading)
+
+- 2M context length
+- Cache offloading enabled
+- Tested model: `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8`
+- Testwd GPU: 8x H100 80GB
+- Tested at: 2025-05-19
+- Tested version:
+  - `hip-attention`: `3974c558f79149584847576ad27a7adf32d30be5`
+  - `sglang` ([DeepAuto-AI/sglang](https://github.com/DeepAuto-AI/sglang)): `8125e3e029a9f90c7800199d1a9939ffda5fa871`
+
+#### Local
+```bash
+HIP_CONFIG_PRESET=llama4 \
+HIP_DISABLE_FLASHDECODE=1 \
+HIP_HEAD_REDUCE=0 \
+HIP_DEBUG_FORCE_DENSE_DECODE=0 \
+uv run \
+--env-file ".env" \
+-m sglang.launch_server \
+--model-path meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 \
+--served-model-name deepauto/llama-4-maverick-2m-ctx \
+--host 0.0.0.0 \
+--port 30000 \
+--tp 8 \
+--max-total-tokens 2000000 \
+--context-length 2000000 \
+--cuda-graph-bs 1 2 4 8 16 24 32 \
+--max-running-req 32 \
+--chunked-prefill-size 65536 \
+--enable-hip-attention \
+--hip-attention-config '{"using_extend": false, "dense_layers": [0, 1, 2, 3]}' \
+--attention-backend flashinfer \
+--chat-template llama-4 \
+--enable-hip-kv-cache-offload \
+--hip-max-mask-cache-size 131072 \
+--hip-max-sa-cache-size 8192
+```
+
+#### Docker
+
+```bash
+docker run --rm \
+--gpus all \
+--name deepauto-llama-4-maverick-2m-ctx \
+-p 30000:30000 \
+--ipc=host \
+-v ~/.cache/huggingface:/root/.cache/huggingface \
+--env "HF_TOKEN=${HF_TOKEN}" \
+--env "HIP_CONFIG_PRESET=llama4" \
+--env "HIP_DISABLE_FLASHDECODE=0" \
+--env "HIP_HEAD_REDUCE=0" \
+--env "HIP_DEBUG_FORCE_DENSE_DECODE=0" \
+deepauto/hip-attention:v1.2.5-sglang \
+python \
+-m sglang.launch_server \
+--model-path meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 \
+--served-model-name deepauto/llama-4-maverick-2m-ctx \
+--host 0.0.0.0 \
+--port 30000 \
+--tp 8 \
+--max-total-tokens 2000000 \
+--context-length 2000000 \
+--cuda-graph-bs 1 2 4 8 16 24 32 \
+--max-running-req 32 \
+--chunked-prefill-size 65536 \
+--enable-hip-attention \
+--hip-attention-config '{"using_extend": false, "dense_layers": [0, 1, 2, 3]}' \
+--attention-backend flashinfer \
+--chat-template llama-4 \
+--enable-hip-kv-cache-offload \
+--hip-max-mask-cache-size 131072 \
+--hip-max-sa-cache-size 8192
+```
+
+## `Qwen/Qwen3-30B-A3B`
+
+### 32K -\> 2M Context (without cache offloading)
+
+- 2M context length
+- Cache offloading disabled
+- Tested model: `Qwen/Qwen3-30B-A3B`
+- Testwd GPU: 8x H100 80GB
+- Tested at: 2025-05-19
+- Tested version:
+  - `hip-attention`: `3974c558f79149584847576ad27a7adf32d30be5`
+  - `sglang` ([DeepAuto-AI/sglang](https://github.com/DeepAuto-AI/sglang)): `8125e3e029a9f90c7800199d1a9939ffda5fa871`
+
+#### Local
+
+```bash
+HIP_CONFIG_PRESET=qwen3 \
+HIP_DISABLE_FLASHDECODE=0 \
+HIP_HEAD_REDUCE=1 \
+HIP_DEBUG_FORCE_DENSE_DECODE=1 \
+uv run \
+--env-file ".env" \
+-m sglang.launch_server \
+--model-path Qwen/Qwen3-30B-A3B \
+--served-model-name deepauto/qwen3-30b-a3b-2m-ctx \
+--host 0.0.0.0 \
+--port 30000 \
+--tp 8 \
+--max-total-tokens 2000000 \
+--context-length 2000000 \
+--cuda-graph-bs 1 2 4 8 16 24 32 \
+--max-running-req 32 \
+--chunked-prefill-size 65536 \
+--enable-hip-attention \
+--attention-backend flashinfer
+```
+
+#### Docker
+
+```bash
+docker run --rm \
+--gpus all \
+--name deepauto-qwen3-30b-a3b-2m-ctx \
+-p 30000:30000 \
+--ipc=host \
+-v ~/.cache/huggingface:/root/.cache/huggingface \
+--env "HF_TOKEN=${HF_TOKEN}" \
+--env "HIP_CONFIG_PRESET=qwen3" \
+--env "HIP_DISABLE_FLASHDECODE=0" \
+--env "HIP_HEAD_REDUCE=1" \
+--env "HIP_DEBUG_FORCE_DENSE_DECODE=1" \
+deepauto/hip-attention:v1.2.5-sglang \
+python \
+-m sglang.launch_server \
+--model-path Qwen/Qwen3-30B-A3B \
+--served-model-name deepauto/qwen3-30b-a3b-2m-ctx \
+--host 0.0.0.0 \
+--port 30000 \
+--tp 8 \
+--max-total-tokens 2000000 \
+--context-length 2000000 \
+--cuda-graph-bs 1 2 4 8 16 24 32 \
+--max-running-req 32 \
+--chunked-prefill-size 65536 \
+--enable-hip-attention \
+--attention-backend flashinfer
+```
+
+### 32K -\> 5M Context (with cache offloading)
+
+- 5M context length
+- Cache offloading enabled
+- Tested model: `Qwen/Qwen3-30B-A3B`
+- Testwd GPU: 8x H100 80GB
+- Tested at: 2025-05-19
+- Tested version:
+  - `hip-attention`: `3974c558f79149584847576ad27a7adf32d30be5`
+  - `sglang` ([DeepAuto-AI/sglang](https://github.com/DeepAuto-AI/sglang)): `8125e3e029a9f90c7800199d1a9939ffda5fa871`
+
+#### Local
+
+```bash
+HIP_CONFIG_PRESET=qwen3 \
+HIP_DISABLE_FLASHDECODE=0 \
+HIP_HEAD_REDUCE=1 \
+HIP_DEBUG_FORCE_DENSE_DECODE=1 \
+uv run \
+--env-file ".env" \
+-m sglang.launch_server \
+--model-path Qwen/Qwen3-30B-A3B \
+--served-model-name deepauto/qwen3-30b-a3b-5m-ctx \
+--host 0.0.0.0 \
+--port 30000 \
+--tp 8 \
+--max-total-tokens 5000000 \
+--context-length 5000000 \
+--cuda-graph-bs 1 2 4 8 16 24 32 \
+--max-running-req 32 \
+--chunked-prefill-size 65536 \
+--enable-hip-attention \
+--attention-backend flashinfer \
+--enable-hip-kv-cache-offload \
+--hip-max-mask-cache-size 266144 \
+--hip-max-sa-cache-size 16384
+```
+
+#### Docker
+
+```bash
+docker run --rm \
+--gpus all \
+--name deepauto-qwen3-30b-a3b-5m-ctx \
+-p 30000:30000 \
+--ipc=host \
+-v ~/.cache/huggingface:/root/.cache/huggingface \
+--env "HF_TOKEN=${HF_TOKEN}" \
+--env "HIP_CONFIG_PRESET=qwen3" \
+--env "HIP_DISABLE_FLASHDECODE=0" \
+--env "HIP_HEAD_REDUCE=1" \
+--env "HIP_DEBUG_FORCE_DENSE_DECODE=1" \
+deepauto/hip-attention:v1.2.5-sglang \
+python \
+-m sglang.launch_server \
+--model-path Qwen/Qwen3-30B-A3B \
+--served-model-name deepauto/qwen3-30b-a3b-5m-ctx \
+--host 0.0.0.0 \
+--port 30000 \
+--tp 8 \
+--max-total-tokens 5000000 \
+--context-length 5000000 \
+--cuda-graph-bs 1 2 4 8 16 24 32 \
+--max-running-req 32 \
+--chunked-prefill-size 65536 \
+--enable-hip-attention \
+--attention-backend flashinfer \
+--enable-hip-kv-cache-offload \
+--hip-max-mask-cache-size 266144 \
+--hip-max-sa-cache-size 16384
 ```

--- a/docs/USAGE.sglang.md
+++ b/docs/USAGE.sglang.md
@@ -70,7 +70,7 @@ SRT_PORT=30000 uv run scripts/test_openai_long.py
 - Cache offloading enabled
 - For cache offloading, KV cache type is `fp8_e5m2`
 - Tested model: `hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4`
-- Testwd GPU: 1x L40S 48GB
+- Tested GPU: 1x L40S 48GB
 - Tested at: 2025-01-29
 - Tested version:
   - `hip-attention`: `a1f2578e0b8d948efdb7df10bad89be0b09c47c6`
@@ -113,7 +113,7 @@ uv run -m sglang.launch_server \
 - 2M context length
 - Cache offloading disabled
 - Tested model: `meta-llama/Llama-3.1-8B-Instruct`
-- Testwd GPU: 1x L40S 48GB
+- Tested GPU: 1x L40S 48GB
 - Tested at: 2025-01-29
 - Tested version:
   - `hip-attention`: `a1f2578e0b8d948efdb7df10bad89be0b09c47c6`
@@ -156,7 +156,7 @@ uv run -m sglang.launch_server \
 - With cache offloading
 - For cache offloading, KV cache type is `fp8_e5m2`
 - Tested model: `hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4`
-- Testwd GPU: 2x A100 40GB
+- Tested GPU: 2x A100 40GB
 - Tested at: 2025-01-29
 - Tested version:
   - `hip-attention`: `a1f2578e0b8d948efdb7df10bad89be0b09c47c6`
@@ -236,7 +236,7 @@ python \
 - 2M context length
 - Cache offloading enabled
 - Tested model: `neody/r1-14b-awq`
-- Testwd GPU: 1x L40S 48GB
+- Tested GPU: 1x L40S 48GB
 - Tested at: 2025-01-29
 - Tested version:
   - `hip-attention`: `a1f2578e0b8d948efdb7df10bad89be0b09c47c6`
@@ -323,7 +323,7 @@ python \
 - 1M context length
 - Cache offloading enabled
 - Tested model: `deepseek-ai/DeepSeek-R1-Distill-Qwen-14B`
-- Testwd GPU: 4x A100 40GB
+- Tested GPU: 4x A100 40GB
 - Tested at: 2025-02-10
 - Tested version:
   - `hip-attention`: `1f346394bf98c4f53b3484d83c746435038b5b98`
@@ -420,7 +420,7 @@ python \
 - 1M context length
 - Cache offloading enabled
 - Tested model: `deepseek-ai/DeepSeek-R1-Distill-Qwen-32B`
-- Testwd GPU: 4x A100 40GB
+- Tested GPU: 4x A100 40GB
 - Tested at: 2025-02-07
 - Tested version:
   - `hip-attention`: `1f346394bf98c4f53b3484d83c746435038b5b98`
@@ -517,7 +517,7 @@ python \
 - 1M context length
 - Cache offloading enabled
 - Tested model: `Qwen/QwQ-32B`
-- Testwd GPU: 4x A100 40GB
+- Tested GPU: 4x A100 40GB
 - Tested at: 2025-04-06
 - Tested version:
   - `hip-attention`: `600d3b614e6da8dd26c38f91d0245d046a90a046`
@@ -602,7 +602,7 @@ python \
 - 1M context length
 - Cache offloading enabled
 - Tested model: `casperhansen/llama-3.3-70b-instruct-awq`
-- Testwd GPU: 4x A100 40GB
+- Tested GPU: 4x A100 40GB
 - Tested at: 2025-04-06
 - Tested version:
   - `hip-attention`: `600d3b614e6da8dd26c38f91d0245d046a90a046`
@@ -686,7 +686,7 @@ python \
 - 1M context length
 - Cache offloading disabled
 - Tested model: `meta-llama/Llama-4-Scout-17B-16E-Instruct`
-- Testwd GPU: 8x H100 80GB
+- Tested GPU: 8x H100 80GB
 - Tested at: 2025-05-19
 - Tested version:
   - `hip-attention`: `3974c558f79149584847576ad27a7adf32d30be5`
@@ -758,7 +758,7 @@ python \
 - 2M context length
 - Cache offloading enabled
 - Tested model: `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8`
-- Testwd GPU: 8x H100 80GB
+- Tested GPU: 8x H100 80GB
 - Tested at: 2025-05-19
 - Tested version:
   - `hip-attention`: `3974c558f79149584847576ad27a7adf32d30be5`
@@ -835,7 +835,7 @@ python \
 - 2M context length
 - Cache offloading disabled
 - Tested model: `Qwen/Qwen3-30B-A3B`
-- Testwd GPU: 8x H100 80GB
+- Tested GPU: 8x H100 80GB
 - Tested at: 2025-05-19
 - Tested version:
   - `hip-attention`: `3974c558f79149584847576ad27a7adf32d30be5`
@@ -901,7 +901,7 @@ python \
 - 5M context length
 - Cache offloading enabled
 - Tested model: `Qwen/Qwen3-30B-A3B`
-- Testwd GPU: 8x H100 80GB
+- Tested GPU: 8x H100 80GB
 - Tested at: 2025-05-19
 - Tested version:
   - `hip-attention`: `3974c558f79149584847576ad27a7adf32d30be5`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hip-attn"  # Name of package when installed using pip
-version = "1.2.4"
+version = "1.2.5"
 description = "HiP Attention"
 authors = [
     { name="DeepAuto.ai", email="contact@deepauto.ai" },

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ wheels = [
 
 [[package]]
 name = "hip-attn"
-version = "1.2.4"
+version = "1.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "bitsandbytes" },


### PR DESCRIPTION
Tested against:
- meta-llama/Llama-4-Scout-17B-16E-Instruct
- meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
- Qwen/Qwen3-30B-A3B

Uploaded to:
- PyPI: `1.2.5`: https://pypi.org/project/hip-attn/1.2.5/
- Docker: `deepauto/hip-attention:v1.2.5-sglang`: https://hub.docker.com/r/deepauto/hip-attention/tags