### PR TITLE
Feat: Add Watchdog to Revive Server Node

### DIFF
--- a/src/hip_attn/utils/sglang_watchdog.py
+++ b/src/hip_attn/utils/sglang_watchdog.py
@@ -1,0 +1,124 @@
+import datetime
+import sys
+import os
+import subprocess
+import threading
+import time
+import requests
+
+def log(*args):
+    comment = " ".join([str(a) for a in args])
+    timestamp = "{:%Y-%m-%d %H:%M:%S}".format(datetime.datetime.now())
+    print(f"\033[91m[{timestamp} sglang_watchdog] {comment}\033[0m", flush=True)
+
+class Watchdog:
+    def __init__(
+        self,
+        timeout_bootup = 300,
+    ):
+        self.timeout_bootup = 300
+        self.timeout_tick = 60
+        self.sleep_step = 1
+        self.proc: subprocess.Popen = None
+        self.argv: list[str] = None
+        self.running: bool = True
+
+    def start_subprocess(self):
+        args = [
+            "python",
+            "-m",
+            "sglang.launch_server",
+            *self.argv
+        ]
+        flatten_args = " ".join(args)
+        log(f"Start subprocess using following command: {flatten_args}")
+        self.proc = subprocess.Popen(args)
+        log(f"Start subprocess communication.")
+        return_code = self.proc.wait()
+        log(f"Return code is {return_code}")
+
+    def kill_subprocess(self):
+        log(f"Start kill subprocess")
+        self.proc.kill()
+        self.proc = None
+        log(f"Finish kill subprocess")
+
+    def wait_for_health(self, timeout: int):
+        t_start = time.time()
+        while (time.time() - t_start) < timeout:
+            try:
+                response = requests.get(self.health_endpoint, timeout=timeout)
+                response.raise_for_status()
+                return
+            except requests.ConnectionError:
+                time.sleep(self.sleep_step)
+        raise TimeoutError()
+
+    def main_watchdog(self):
+        while True:
+            try:
+                t_boot = time.time()
+                booted = False
+                while (
+                    (time.time() - t_boot) < self.timeout_bootup
+                    and self.proc.returncode is None
+                    and not booted
+                ):
+                    try:
+                        self.wait_for_health(timeout=self.timeout_bootup)
+                        booted = True
+                    except (TimeoutError, requests.HTTPError):
+                        # NOTE: may process is not started yet
+                        pass
+                    time.sleep(self.sleep_step)
+            
+                if not booted: raise TimeoutError()
+            
+                while True:
+                    self.wait_for_health(timeout=self.timeout_tick)
+                    time.sleep(self.sleep_step)
+            
+            except (TimeoutError, requests.HTTPError):
+                self.kill_subprocess()
+            time.sleep(self.sleep_step)
+
+    def main_starter(self):
+        while True:
+            self.start_subprocess()
+            time.sleep(self.sleep_step)
+    
+    def start(self):
+        if "--" in sys.argv:
+            argv = sys.argv[sys.argv.index("--") + 1:]
+        else:
+            argv = sys.argv[1:]
+        
+        assert "--host" in argv
+        assert "--port" in argv
+        self.host = argv[argv.index("--host") + 1]
+        self.port = argv[argv.index("--port") + 1]
+        self.health_endpoint = f"http://{self.host}:{self.port}/health"
+        log(f"Watching: {self.health_endpoint}")
+
+        self.argv = argv
+
+        self.thread_watchdog = threading.Thread(
+            target=self.main_watchdog, 
+            daemon=True
+        )
+        self.thread_starter = threading.Thread(
+            target=self.main_starter, 
+            daemon=True
+        )
+
+        self.thread_watchdog.start()
+        self.thread_starter.start()
+
+        self.thread_watchdog.join()
+        self.thread_starter.join()
+
+        self.running = False
+
+if __name__ == '__main__':
+    dog = Watchdog()
+    dog.start()

--- a/src/hip_attn/utils/sglang_watchdog.py
+++ b/src/hip_attn/utils/sglang_watchdog.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import threading
 import time
+import traceback
 import requests
 
 def log(*args):
@@ -52,6 +53,9 @@ class Watchdog:
             try:
                 t_boot = time.time()
                 booted = False
+                while self.proc is None:
+                    log("Watchdog is waiting for process started...")
+                    time.sleep(self.sleep_step)
                 while (
                     (time.time() - t_boot) < self.timeout_bootup
                     and self.proc.returncode is None
@@ -76,6 +80,12 @@ class Watchdog:
             
             except (TimeoutError, requests.HTTPError):
                 self.kill_subprocess()
+            except Exception as ex:
+                trace = traceback.format_exc()
+                log(f"Traceback:\n{trace}")
+                log(f"Unexpected error on watchdog thread: {ex}")
+                self.kill_subprocess()
+            
             time.sleep(self.sleep_step)
 
     def main_starter(self):

--- a/src/hip_attn/utils/sglang_watchdog.py
+++ b/src/hip_attn/utils/sglang_watchdog.py
@@ -44,15 +44,8 @@ class Watchdog:
         log(f"Finish kill subprocess")
 
     def wait_for_health(self, timeout: int):
-        t_start = time.time()
-        while (time.time() - t_start) < timeout:
-            try:
-                response = requests.get(self.health_endpoint, timeout=timeout)
-                response.raise_for_status()
-                return
-            except requests.ConnectionError:
-                time.sleep(self.sleep_step)
-        raise TimeoutError()
+        response = requests.get(self.health_endpoint, timeout=timeout)
+        response.raise_for_status()
 
     def main_watchdog(self):
         while True:
@@ -66,8 +59,9 @@ class Watchdog:
                 ):
                     try:
                         self.wait_for_health(timeout=self.timeout_bootup)
+                        log("Server booted successfully.")
                         booted = True
-                    except (TimeoutError, requests.HTTPError):
+                    except (TimeoutError, requests.HTTPError, requests.ConnectionError):
                         # NOTE: may process is not started yet
                         pass
                     time.sleep(self.sleep_step)
@@ -75,8 +69,10 @@ class Watchdog:
                 if not booted: raise TimeoutError()
             
                 while True:
+                    log("Try watch dog.")
                     self.wait_for_health(timeout=self.timeout_tick)
-                    time.sleep(self.sleep_step)
+                    log("Done watch dog successfully.")
+                    time.sleep(self.timeout_tick)
             
             except (TimeoutError, requests.HTTPError):
                 self.kill_subprocess()
@@ -111,8 +107,9 @@ class Watchdog:
             daemon=True
         )
 
-        self.thread_watchdog.start()
         self.thread_starter.start()
+        time.sleep(self.sleep_step)
+        self.thread_watchdog.start()
 
         self.thread_watchdog.join()
         self.thread_starter.join()


### PR DESCRIPTION
### Watchdog (Single Node) Command
```
BSA_K=32 \
BSA_EXACT_K=32 \
BSA_BLOCK_K=64 \
HIP_DEBUG_DELTA_QSA=1 \
HIP_DEBUG_RECOMPUTE_SPLIT=0 \
TRITON_PRINT_AUTOTUNING=1 \
SRT_WARMUP_ALL_SEQ_LENS=0 \
HIP_DEBUG_FA3_MIXING_LEN=0 \
PASSKEY_DECODE_LEN=128 \
PASSKEY_LEN=150 \
SA_BLOCK_SIZE=128 \
SA_DECODE_BLOCK_SIZE=128 \
HIP_DISABLE_AUTOTUNE=0 \
HIP_DEBUG=0 \
HIP_DEBUG_BENCH=0 \
HIP_DEBUG_CAPTURE_DECORATOR=1 \
CUDA_LAUNCH_BLOCKING=0 \
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
$(which python) -m hip_attn.utils.sglang_watchdog \
-- \
--host 0.0.0.0 \
--port 8000 \
--model-path Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
--kv-cache-dtype auto \
--ep-size 8 \
--tp-size 8 \
--chunked-prefill-size 65536 \
--max-prefill-tokens 65536 \
--cuda-graph-bs 1 2 4 8 16 24 32 48 64 96 128 160 192 256 \
--context-length 256000 \
--max-total-tokens 256000 \
--attention-backend hip_attention \
--hip-attention-config ./configs/mixed_landmark_0814_no_extend_qsa.json \
--hip-attention-config-override-json '{"__seq_thresh_fa3": 65536}' \
--json-model-override-args  '{"rope_scaling":{"rope_type":"yarn","factor":1.0,"original_max_position_embeddings":262144}, "max_position_embeddings": 262144}' \
--max-running-requests 64 \
--trust-remote-code \
--tool-call-parser qwen25
```

### Router Command

```
./target/release/sglang-router \
    --host 0.0.0.0 --port 30000 \
    --worker-urls \
        http://h100-80-1:8000 \
        http://h100-80-2:8000 \
    --prometheus-host 0.0.0.0 \
    --prometheus-port 9000
```